### PR TITLE
24 commitment state updates

### DIFF
--- a/src/v1_0_0/Billing.sol
+++ b/src/v1_0_0/Billing.sol
@@ -166,7 +166,7 @@ abstract contract Billing is IBilling, Routable {
         }
 
         if (result == FulfillResult.FULFILLED && isLastDelivery == true) {
-            delete s_requestCommitments[commitment.requestId];
+            _cleanupRequestState(commitment.requestId, commitment.subscriptionId, commitment.interval, proofSubmitter);
         }
     }
 
@@ -340,6 +340,24 @@ abstract contract Billing is IBilling, Routable {
     }
 
     function _cancelRequest(bytes32 requestId) internal virtual {
+        delete s_requestCommitments[requestId];
+    }
+
+    /// @notice Cleans up the state associated with a request after it has been fulfilled.
+    /// @dev This function is designed to be overridden by child contracts to include
+    ///      additional state cleanup, such as resetting redundancy counts or response tracking.
+    ///      The `proofSubmitter` parameter is provided to allow child contracts to clean up
+    ///      node-specific state.
+    /// @param requestId The unique identifier of the request.
+    /// @param subscriptionId The ID of the subscription associated with the request.
+    /// @param interval The interval of the request.
+    /// @param proofSubmitter The address of the node that submitted the proof.
+    function _cleanupRequestState(bytes32 requestId, uint64 subscriptionId, uint32 interval, address proofSubmitter)
+        internal
+        virtual
+    {
+        // Base implementation cleans up the commitment.
+        // Child contracts can override this to add more cleanup logic.
         delete s_requestCommitments[requestId];
     }
 

--- a/src/v1_0_0/Coordinator.sol
+++ b/src/v1_0_0/Coordinator.sol
@@ -197,9 +197,13 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
         if (s_requestCommitments[commitment.requestId] != keccak256(commitmentData)) {
             revert InvalidCommitment();
         }
-        // verify the delivery interval matches subscription's current interval
+        // Verify the delivery interval. For recurring subscriptions, it must match the current calculated interval.
+        // For one-shot subscriptions (`interval` is `type(uint32).max`), it must match the interval stored in the commitment.
         uint32 interval = _getRouter().getComputeSubscriptionInterval(commitment.subscriptionId);
-        if (interval != deliveryInterval) {
+        if (
+            (interval != type(uint32).max && interval != deliveryInterval)
+                || (interval == type(uint32).max && commitment.interval != deliveryInterval)
+        ) {
             revert IntervalMismatch(deliveryInterval);
         }
         // validate the nodeWallet is a recognized wallet produced by the WalletFactory
@@ -210,8 +214,8 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
             revert InvalidWallet();
         }
         // prevent the same node (msg.sender) from responding twice for the same subscription/interval
-        bytes32 nodeResponseKey = keccak256(abi.encode(commitment.subscriptionId, interval, msg.sender));
-        if (nodeResponded[nodeResponseKey]) {
+        bytes32 nodeResponseKey = keccak256(abi.encode(commitment.subscriptionId, commitment.interval, msg.sender));
+        if (nodeResponded[nodeResponseKey] == true) {
             revert NodeRespondedAlready();
         }
         nodeResponded[nodeResponseKey] = true;

--- a/src/v1_0_0/Coordinator.sol
+++ b/src/v1_0_0/Coordinator.sol
@@ -29,8 +29,12 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
     mapping(bytes32 => uint16) public redundancyCount;
 
     /// @notice Tracks whether a node has already responded for a given subscription/interval.
-    /// key = keccak256(subscriptionId, interval, nodeAddress)
+    /// @dev key: keccak256(abi.encode(subscriptionId, interval, nodeAddress))
     mapping(bytes32 => bool) public nodeResponded;
+
+    /// @notice Tracks the addresses of nodes that have responded to a specific request.
+    /// @dev key: requestId (keccak256(abi.encode(subscriptionId, interval)))
+    mapping(bytes32 => address[]) private s_respondedNodes;
 
     /*//////////////////////////////////////////////////////////////////////////
                                   CONSTRUCTOR
@@ -77,7 +81,7 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
             wallet,
             verifier
         );
-
+        redundancyCount[requestId] = 0;
         emit RequestStarted(requestId, subscriptionId, containerId, commitment);
         return commitment;
     }
@@ -184,10 +188,14 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
     ) internal {
         // decode commitment supplied by caller (router produced this when request was started)
         Commitment memory commitment = abi.decode(commitmentData, (Commitment));
+
         // check redundancy limit for this request: if already reached, revert
         uint16 currentRedundancy = redundancyCount[commitment.requestId];
         if (currentRedundancy >= commitment.redundancy) {
             revert IntervalCompleted();
+        }
+        if (s_requestCommitments[commitment.requestId] != keccak256(commitmentData)) {
+            revert InvalidCommitment();
         }
         // verify the delivery interval matches subscription's current interval
         uint32 interval = _getRouter().getComputeSubscriptionInterval(commitment.subscriptionId);
@@ -202,12 +210,13 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
             revert InvalidWallet();
         }
         // prevent the same node (msg.sender) from responding twice for the same subscription/interval
-        bytes32 key = keccak256(abi.encode(commitment.subscriptionId, interval, msg.sender));
-        if (nodeResponded[key]) {
+        bytes32 nodeResponseKey = keccak256(abi.encode(commitment.subscriptionId, interval, msg.sender));
+        if (nodeResponded[nodeResponseKey]) {
             revert NodeRespondedAlready();
         }
-        nodeResponded[key] = true;
+        nodeResponded[nodeResponseKey] = true;
         uint16 newRedundancyCount;
+        s_respondedNodes[commitment.requestId].push(msg.sender);
         unchecked {
             newRedundancyCount = currentRedundancy + 1;
         }
@@ -229,6 +238,20 @@ contract Coordinator is ICoordinator, Billing, ReentrancyGuard, ConfirmedOwner {
     /// @dev ConfirmedOwner abstract hook (required override).
     function _onlyOwner() internal view override {
         _validateOwnership();
+    }
+
+    function _cleanupRequestState(bytes32 requestId, uint64 subscriptionId, uint32 interval, address proofSubmitter)
+        internal
+        override
+    {
+        super._cleanupRequestState(requestId, subscriptionId, interval, proofSubmitter);
+        address[] storage responders = s_respondedNodes[requestId];
+        for (uint256 i = 0; i < responders.length; i++) {
+            bytes32 nodeResponseKey = keccak256(abi.encode(subscriptionId, interval, responders[i]));
+            delete nodeResponded[nodeResponseKey];
+        }
+        // Clean up the responder address array itself.
+        delete s_respondedNodes[requestId];
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/v1_0_0/DelegateeCoordinator.sol
+++ b/src/v1_0_0/DelegateeCoordinator.sol
@@ -35,6 +35,10 @@ contract DelegateeCoordinator is Coordinator {
         uint32 deliveryInterval
     ) internal returns (bytes memory) {
         uint64 subscriptionId = _getRouter().createSubscriptionDelegatee(nonce, expiry, sub, signature);
+        bytes32 requestId = keccak256(abi.encodePacked(subscriptionId, deliveryInterval));
+        if (subscriptionId != 0 && redundancyCount[requestId] >= sub.redundancy) {
+            revert IntervalCompleted();
+        }
         (, Commitment memory commitment) = _getRouter().sendRequest(subscriptionId, deliveryInterval);
         return abi.encode(commitment);
     }

--- a/src/v1_0_0/SubscriptionManager.sol
+++ b/src/v1_0_0/SubscriptionManager.sol
@@ -197,7 +197,6 @@ abstract contract SubscriptionsManager is ISubscriptionsManager, EIP712 {
         if (nonce > maxSubscriberNonce[sub.client]) {
             maxSubscriberNonce[sub.client] = nonce;
         }
-
         return subscriptionId;
     }
 

--- a/src/v1_0_0/SubscriptionManager.sol
+++ b/src/v1_0_0/SubscriptionManager.sol
@@ -318,7 +318,7 @@ abstract contract SubscriptionsManager is ISubscriptionsManager, EIP712 {
         uint32 intervalSeconds = sub.intervalSeconds;
 
         if (uint32(block.timestamp) < activeAt) return 0;
-        if (intervalSeconds == 0) return 1;
+        if (intervalSeconds == 0) return type(uint32).max;
 
         unchecked {
             return ((uint32(block.timestamp) - activeAt) / intervalSeconds) + 1;

--- a/src/v1_0_0/client/ScheduledComputeClient.sol
+++ b/src/v1_0_0/client/ScheduledComputeClient.sol
@@ -9,6 +9,10 @@ import {ComputeClient} from "./ComputeClient.sol";
  * @dev Abstract contract for interacting with the Noosphere Router to manage compute subscriptions.
  */
 abstract contract ScheduledComputeClient is ComputeClient {
+    bool private _computeRequested;
+
+    error ComputeAlreadyRequested();
+
     constructor(address router) ComputeClient(router) {}
 
     function _createComputeSubscription(
@@ -39,6 +43,10 @@ abstract contract ScheduledComputeClient is ComputeClient {
     }
 
     function _requestCompute(uint64 subscriptionId, uint32 interval) internal returns (uint64, Commitment memory) {
+        if (_computeRequested) {
+            revert ComputeAlreadyRequested();
+        }
+        _computeRequested = true;
         (, Commitment memory commitment) = _getRouter().sendRequest(subscriptionId, interval);
         return (subscriptionId, commitment);
     }

--- a/src/v1_0_0/client/TransientComputeClient.sol
+++ b/src/v1_0_0/client/TransientComputeClient.sol
@@ -13,6 +13,9 @@ import {ComputeClient} from "./ComputeClient.sol";
 abstract contract TransientComputeClient is ComputeClient {
     mapping(uint64 => mapping(uint32 => bytes)) internal subscriptionInputs;
 
+    /// @dev A counter to ensure a unique interval for each transient request within a subscription.
+    mapping(uint64 => uint32) private _requestNonces;
+
     constructor(address router) ComputeClient(router) {}
 
     function _createComputeSubscription(
@@ -32,8 +35,10 @@ abstract contract TransientComputeClient is ComputeClient {
     }
 
     function _requestCompute(uint64 subscriptionId, bytes memory inputs) internal returns (uint64, Commitment memory) {
-        // For a transient request, the interval is always 1.
-        uint32 interval = 1;
+        // Increment the nonce for the subscription to get a unique interval for this request.
+        // For transient subscriptions, the 'interval' field is used as a nonce to ensure request uniqueness,
+        // rather than representing a time-based interval.
+        uint32 interval = ++_requestNonces[subscriptionId];
         subscriptionInputs[subscriptionId][interval] = inputs;
         (, Commitment memory commitment) = _getRouter().sendRequest(subscriptionId, interval);
         return (subscriptionId, commitment);

--- a/src/v1_0_0/interfaces/ICoordinator.sol
+++ b/src/v1_0_0/interfaces/ICoordinator.sol
@@ -46,6 +46,7 @@ interface ICoordinator {
                                  ERRORS
     //////////////////////////////////////////////////////////////////////////*/
 
+    error InvalidCommitment();
     error IntervalMismatch(uint32 deliveryInterval);
     error IntervalCompleted();
     error NodeRespondedAlready();

--- a/test/Compute.Delegatee.t.sol
+++ b/test/Compute.Delegatee.t.sol
@@ -469,8 +469,8 @@ contract DelegateeComputeTest is Test, CoordinatorConstants {
         assertEq(out.output, MOCK_OUTPUT);
         assertEq(out.proof, MOCK_PROOF);
 
-        bytes32 key = keccak256(abi.encode(uint64(1), deliveryInterval, address(nodeAlice)));
-        assertEq(coordinator.nodeResponded(key), true);
+        bytes32 requestId = RequestIdUtils.requestIdPacked(uint64(1), deliveryInterval);
+        assertEq(coordinator.redundancyCount(requestId), 1);
     }
 
     /// @notice When a subscription requests inbox delivery, the delegated delivery should store the pending delivery in the client's inbox.
@@ -502,9 +502,6 @@ contract DelegateeComputeTest is Test, CoordinatorConstants {
         assertEq(pd.input, MOCK_INPUT);
         assertEq(pd.output, MOCK_OUTPUT);
         assertEq(pd.proof, MOCK_PROOF);
-
-        bytes32 key = keccak256(abi.encode(uint64(1), deliveryInterval, address(nodeAlice)));
-        assertEq(coordinator.nodeResponded(key), true);
     }
 
     /// @notice Attempting to deliver for a completed interval must revert.
@@ -518,37 +515,20 @@ contract DelegateeComputeTest is Test, CoordinatorConstants {
 
         uint32 deliveryInterval = 1;
 
-        // record logs to extract events emitted by coordinator during atomic delivery
-        vm.recordLogs();
+        // 1. First call: This should succeed, create the subscription, and complete the request.
         nodeAlice.reportDelegatedComputeResult(
             nonce, expiry, sub, signature, deliveryInterval, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, aliceWalletAddr
         );
 
-        // find RequestStarted Commitment in recorded logs
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bytes32 requestStartedTopic = ICoordinator.RequestStarted.selector;
-        Commitment memory commitment;
-        bool found = false;
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].topics[0] == requestStartedTopic) {
-                commitment = abi.decode(logs[i].data, (Commitment));
-                found = true;
-                break;
-            }
-        }
-        assertTrue(found, "RequestStarted event not emitted");
-        assertEq(commitment.subscriptionId, uint64(1));
+        // The request is now complete because redundancy (1) has been met.
+        // The commitment has been deleted from the Coordinator's state.
 
-        // subsequent deliveries for the same interval should revert with IntervalCompleted
+        // 2. Second call: Attempt to deliver for the same (now completed) request.
+        // This should revert because the commitment is no longer valid/active.
+        // The subscription itself is NOT recreated due to idempotency.
         vm.expectRevert(ICoordinator.IntervalCompleted.selector);
         nodeBob.reportDelegatedComputeResult(
             nonce, expiry, sub, signature, deliveryInterval, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, bobWalletAddr
-        );
-
-        bytes memory commitmentData = abi.encode(commitment);
-        vm.expectRevert(ICoordinator.IntervalCompleted.selector);
-        nodeBob.reportComputeResult(
-            deliveryInterval, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, commitmentData, bobWalletAddr
         );
     }
 
@@ -568,15 +548,15 @@ contract DelegateeComputeTest is Test, CoordinatorConstants {
         nodeAlice.reportDelegatedComputeResult(
             nonce, expiry, sub, signature, deliveryInterval, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, aliceWalletAddr
         );
-        bytes32 key = keccak256(abi.encode(uint64(1), deliveryInterval, address(nodeAlice)));
-        assertEq(coordinator.nodeResponded(key), true);
+        bytes32 requestId = RequestIdUtils.requestIdPacked(uint64(1), deliveryInterval);
+        assertEq(coordinator.redundancyCount(requestId), 1);
 
         // second node responds
         nodeBob.reportDelegatedComputeResult(
             nonce, expiry, sub, signature, deliveryInterval, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, bobWalletAddr
         );
-        key = keccak256(abi.encode(uint64(1), deliveryInterval, address(nodeBob)));
-        assertEq(coordinator.nodeResponded(key), true);
+        // The request is now complete (redundancy 2 of 2 met).
+        assertEq(coordinator.redundancyCount(requestId), 2);
 
         // a duplicate attempt from the same node should revert
         vm.expectRevert(ICoordinator.IntervalCompleted.selector);

--- a/test/Compute.Subscription.t.sol
+++ b/test/Compute.Subscription.t.sol
@@ -147,7 +147,7 @@ contract ComputeSubscriptionTest is ComputeTest {
 
         // The call chain is reportComputeResult -> getSubscriptionInterval -> _isExistingSubscription.
         // This will revert with "InvalidSubscription".
-        vm.expectRevert(bytes("SubscriptionNotFound()"));
+        vm.expectRevert(bytes("InvalidCommitment()"));
 
         // Call reportComputeResult with the crafted commitment.
         alice.reportComputeResult(1, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, commitmentData, address(alice));

--- a/test/Compute.Timeout.t.sol
+++ b/test/Compute.Timeout.t.sol
@@ -121,9 +121,9 @@ contract ComputeTimeoutRequestTest is ComputeTest, ISubscriptionManagerErrors {
 
         // 3. Attempt to deliver compute for the now-timed-out request.
         // It should revert because the coordinator detects a mismatch between the
-        // delivery interval (1) and the current system interval (2).
+        // commitment is no longer valid after being timed out.
         bytes memory commitmentData1 = abi.encode(commitment1);
-        vm.expectRevert(abi.encodeWithSelector(ICoordinator.IntervalMismatch.selector, 1));
+        vm.expectRevert(ICoordinator.InvalidCommitment.selector);
         vm.prank(address(bob));
         bob.reportComputeResult(1, MOCK_INPUT, MOCK_OUTPUT, MOCK_PROOF, commitmentData1, nodeWallet);
     }

--- a/test/SubscriptionBatchReader.t.sol
+++ b/test/SubscriptionBatchReader.t.sol
@@ -161,12 +161,12 @@ contract SubscriptionBatchReaderTest is ComputeTest {
     function test_Succeeds_When_QueryingRedundancyCounts() public {
         // Create first subscription (maxExecutions = 2, redundancy = 2)
         vm.warp(0);
-        (uint64 subOne,) = ScheduledClient.createMockSubscription(
+        uint64 subOne = ScheduledClient.createMockSubscriptionWithoutRequest(
             MOCK_CONTAINER_ID, 2, 10 minutes, 2, false, NO_PAYMENT_TOKEN, 0, userWalletAddress, NO_VERIFIER
         );
 
         // Create second subscription (maxExecutions = 1, redundancy = 1)
-        (uint64 subTwo,) = ScheduledClient.createMockSubscription(
+        uint64 subTwo = ScheduledClient.createMockSubscriptionWithoutRequest(
             MOCK_CONTAINER_ID, 1, 10 minutes, 1, false, NO_PAYMENT_TOKEN, 0, userWalletAddress, NO_VERIFIER
         );
 

--- a/webapp/src/agent.js
+++ b/webapp/src/agent.js
@@ -102,7 +102,6 @@ async function main() {
     console.log(`   Node Signer (EOA): ${nodeSigner.address}`);
 
     const coordinatorContract = new ethers.Contract(COORDINATOR_ADDRESS, CoordinatorArtifact.abi, nodeSigner);
-    const clientContract = new ethers.Contract(CLIENT_ADDRESS, ClientArtifact.abi, provider); // Read-only is fine
     const routerContract = new ethers.Contract(ROUTER_ADDRESS, RouterArtifact.abi, provider);
 
     console.log(`   Router Address: ${ROUTER_ADDRESS}`);
@@ -151,7 +150,9 @@ async function main() {
         try {
             // 1. Get the inputs for the computation from the client contract
             console.log("   1. Fetching compute inputs...");
-            const inputs = await clientContract.getComputeInputs(subscriptionId, 1, now(), nodePaymentWalletAddress);
+            const subscription = await routerContract.getComputeSubscription(commitment.subscriptionId);
+            const clientContract = new ethers.Contract(subscription.client, ClientArtifact.abi, provider); // Read-only is fine
+            const inputs = await clientContract.getComputeInputs(subscriptionId, commitment.interval, now(), nodePaymentWalletAddress);
             console.log(`      Inputs received: ${inputs}`);
 
             // [EXAMPLE] Get the delegated signer from the client contract
@@ -164,14 +165,14 @@ async function main() {
             const timestamp = new Date().toISOString();
             // Generate a long string for testing purposes (approx. 1000 chars)
             const longText = "This is a long string for testing data transmission. It repeats multiple times to increase its length and simulate a more realistic payload that a compute job might return. This helps in verifying that the system can handle larger data sizes without issues. 1. ".repeat(5);
-            const rawOutput = `I am GPT. Processed at: ${timestamp}. Payload: ${longText}`;
+            const rawOutput = `I am GPT. Processed at: ${timestamp}. Inputs: ${ethers.toUtf8String(inputs)}. Payload: ${longText}`;
             const outputBytes = ethers.hexlify(ethers.toUtf8Bytes(rawOutput));
 
             console.log(`   2. Computation finished. Output: "${rawOutput}" (bytes: ${outputBytes})`);
 
             // 3. Verify commitment data from multiple sources and prepare for reporting
             console.log("   3. Verifying commitment data and preparing report...");
-            const subscription = await routerContract.getComputeSubscription(subscriptionId);
+            // const subscription = await routerContract.getComputeSubscription(subscriptionId);
 
             // Source 1: From the event itself
             const eventCommitment = new Commitment(commitment);
@@ -240,7 +241,7 @@ async function main() {
             }
 
             if (requestProcessedEvent) {
-                console.log("   ✅ Settlement event (RequesㄲㄲProcessed) detected!");
+                console.log("   ✅ Settlement event (RequesProcessed) detected!");
                 const eventBlockNumber = requestProcessedEvent.blockNumber;
                 console.log(`      Block: ${eventBlockNumber}, Tx: ${reportReceipt.hash}`);
 

--- a/webapp/src/agent.js
+++ b/webapp/src/agent.js
@@ -105,6 +105,9 @@ async function main() {
     const clientContract = new ethers.Contract(CLIENT_ADDRESS, ClientArtifact.abi, provider); // Read-only is fine
     const routerContract = new ethers.Contract(ROUTER_ADDRESS, RouterArtifact.abi, provider);
 
+    console.log(`   Router Address: ${ROUTER_ADDRESS}`);
+
+
     // --- Create a dedicated Wallet for the Node to receive payments ---
     console.log("\n🤖 Ensuring node has a payment wallet...");
     const walletFactoryAddress = await routerContract.getWalletFactory();
@@ -157,9 +160,14 @@ async function main() {
             console.log(`      Delegated Signer for client ${await clientContract.getAddress()}: ${delegatedSigner}`);
             // This delegatedSigner address is the one that would be used to sign off-chain messages for `createSubscriptionDelegatee`.
 
-            // 2. "Perform" the computation (we'll just return a dummy value)
-            const output = "0x5678"; // Our "computed" result
-            console.log(`   2. Computation finished. Output: ${output}`);
+            // 2. "Perform" the computation and convert output to hex
+            const timestamp = new Date().toISOString();
+            // Generate a long string for testing purposes (approx. 1000 chars)
+            const longText = "This is a long string for testing data transmission. It repeats multiple times to increase its length and simulate a more realistic payload that a compute job might return. This helps in verifying that the system can handle larger data sizes without issues. 1. ".repeat(5);
+            const rawOutput = `I am GPT. Processed at: ${timestamp}. Payload: ${longText}`;
+            const outputBytes = ethers.hexlify(ethers.toUtf8Bytes(rawOutput));
+
+            console.log(`   2. Computation finished. Output: "${rawOutput}" (bytes: ${outputBytes})`);
 
             // 3. Verify commitment data from multiple sources and prepare for reporting
             console.log("   3. Verifying commitment data and preparing report...");
@@ -189,10 +197,24 @@ async function main() {
 
             // 4. Report the result back to the Coordinator
             console.log("   4. Reporting compute result to Coordinator...");
+            console.log(`      Commitment Details:`);
+            console.log(`         Request ID: ${eventCommitment.data.requestId}`);
+            console.log(`         Subscription ID: ${eventCommitment.data.subscriptionId}`);
+            console.log(`         Container ID: ${eventCommitment.data.containerId}`);
+            console.log(`         Interval: ${eventCommitment.data.interval}`);
+            console.log(`         Use Delivery Inbox: ${eventCommitment.data.useDeliveryInbox}`);
+            console.log(`         Redundancy: ${eventCommitment.data.redundancy}`);
+            console.log(`         Wallet Address: ${eventCommitment.data.walletAddress}`);
+            console.log(`         Fee Amount: ${eventCommitment.data.feeAmount}`);
+            console.log(`         Fee Token: ${eventCommitment.data.feeToken}`);
+            console.log(`         Verifier: ${eventCommitment.data.verifier}`);
+            console.log(`         Coordinator: ${eventCommitment.data.coordinator}`);
+
+
             const reportTx = await coordinatorContract.reportComputeResult(
                 commitment.interval,
                 inputs,
-                output,
+                outputBytes,
                 "0x", // proof (placeholder)
                 eventCommitment.encode(), // Use the reconstructed data for the report
                 nodePaymentWalletAddress // The node's dedicated Wallet contract that will receive payment
@@ -218,7 +240,7 @@ async function main() {
             }
 
             if (requestProcessedEvent) {
-                console.log("   ✅ Settlement event (RequestProcessed) detected!");
+                console.log("   ✅ Settlement event (RequesㄲㄲProcessed) detected!");
                 const eventBlockNumber = requestProcessedEvent.blockNumber;
                 console.log(`      Block: ${eventBlockNumber}, Tx: ${reportReceipt.hash}`);
 

--- a/webapp/src/onchain_verify_agent.js
+++ b/webapp/src/onchain_verify_agent.js
@@ -68,6 +68,9 @@ async function main() {
     const routerContract = new ethers.Contract(ROUTER_ADDRESS, RouterArtifact.abi, provider);
     const verifierContract = new ethers.Contract(IMMEDIATE_FINALIZE_VERIFIER_ADDRESS, ImmediateFinalizeVerifierArtifact.abi, provider);
 
+    console.log(`   ImmediateFinalizeVerifier Address: ${IMMEDIATE_FINALIZE_VERIFIER_ADDRESS}`);
+
+
     // --- Create a dedicated Wallet for the Node to receive payments ---
     console.log("\n🤖 Ensuring node has a payment wallet...");
     const walletFactoryAddress = await routerContract.getWalletFactory();
@@ -251,8 +254,7 @@ async function main() {
                     commitment: {type: 'inline', value: encodedCommitmentData},
                     // Ensure inputs and outputs are consistently hexlified to prevent hash mismatches.
                     input: {type: 'inline', value: ethers.hexlify(ethers.toUtf8Bytes(inputs))},
-                    output: {type: 'inline', value: ethers.hexlify(ethers.toUtf8Bytes(output))},
-                    timestamp: now()
+                    output: {type: 'inline', value: ethers.hexlify(ethers.toUtf8Bytes(output))}
                 }
             };
 


### PR DESCRIPTION
Modified the interval calculation to distinguish between one-shot and recurring subscriptions, preventing request ID collisions. Added a single-request guard to ScheduledComputeClient to enforce its intended one-shot usage