### PR TITLE
feat: Add NoosphereVRF shared singleton for verifiable randomness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # -----------------------------------------------------------------------------
 # PHONY targets (force these to run even if a file with the same name exists)
 # -----------------------------------------------------------------------------
-.PHONY: all install clean build test format docs snapshot diff deploy deploy-anvil deploy-hpp-sepolia
+.PHONY: all install clean build test format docs snapshot diff deploy deploy-anvil deploy-hpp-sepolia deploy-vrf deploy-vrf-hpp-sepolia register-epoch
 
 # -----------------------------------------------------------------------------
 # Default target: run dependency install -> clean -> format -> build -> test
@@ -123,6 +123,64 @@ deploy-hpp-sepolia:
 		--verifier blockscout \
 		--verifier-url https://sepolia-explorer.hpp.io/api/ \
 		--sig "run(address,address)" $(PRODUCTION_OWNER_ADDR) $(INITIAL_FEE_RECIPIENT_ADDR)
+
+# -----------------------------------------------------------------------------
+# Deploy NoosphereVRF singleton
+# - Requires: RPC_URL, PRIVATE_KEY
+# - Optional: VRF_OWNER (defaults to deployer address)
+# -----------------------------------------------------------------------------
+deploy-vrf:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ]; then \
+		echo "ERROR: RPC_URL and PRIVATE_KEY environment variables are required."; \
+		exit 1; \
+	fi
+	@echo "=> Deploying NoosphereVRF singleton to $(RPC_URL)..."
+	@forge script scripts/DeployVRF.sol:DeployVRF \
+		--broadcast \
+		--skip-simulation \
+		--gas-estimate-multiplier 130 \
+		--optimize \
+		--optimizer-runs 1000000 \
+		--extra-output-files abi \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY)
+
+deploy-vrf-hpp-sepolia:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ]; then \
+		echo "ERROR: RPC_URL and PRIVATE_KEY environment variables are required."; \
+		exit 1; \
+	fi
+	@echo "=> Deploying NoosphereVRF to HPP Sepolia with verification..."
+	@forge script scripts/DeployVRF.sol:DeployVRF \
+		--broadcast \
+		--skip-simulation \
+		--gas-estimate-multiplier 130 \
+		--optimize \
+		--optimizer-runs 1000000 \
+		--extra-output-files abi \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY) \
+		--verify \
+		--verifier blockscout \
+		--verifier-url https://sepolia-explorer.hpp.io/api/
+
+# -----------------------------------------------------------------------------
+# Register epoch on NoosphereVRF
+# - Requires: RPC_URL, PRIVATE_KEY, VRF_ADDRESS, EPOCH, MERKLE_ROOT
+# -----------------------------------------------------------------------------
+register-epoch:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ] || [ -z "$(VRF_ADDRESS)" ] || [ -z "$(EPOCH)" ] || [ -z "$(MERKLE_ROOT)" ]; then \
+		echo "ERROR: RPC_URL, PRIVATE_KEY, VRF_ADDRESS, EPOCH, MERKLE_ROOT are required."; \
+		exit 1; \
+	fi
+	@echo "=> Registering epoch $(EPOCH) on NoosphereVRF $(VRF_ADDRESS)..."
+	@NOOSPHERE_VRF_ADDRESS=$(VRF_ADDRESS) forge script scripts/RegisterEpoch.sol:RegisterEpoch \
+		--broadcast \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY)
 
 # -----------------------------------------------------------------------------
 # Save gas snapshot (using forge snapshot)

--- a/scripts/DeployVRF.sol
+++ b/scripts/DeployVRF.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.24;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {NoosphereVRF} from "../src/v1_0_0/vrf/NoosphereVRF.sol";
+
+/// @title DeployVRF
+/// @notice Deploys the NoosphereVRF singleton contract.
+///         The singleton is shared across all consumer dApps on a given chain.
+///
+/// Required environment variables:
+///   PRIVATE_KEY          – Deployer private key (pays gas, becomes initial owner unless overridden)
+///   VRF_OWNER            – (Optional) Owner address for the VRF contract. Defaults to deployer.
+///
+/// Usage:
+///   forge script scripts/DeployVRF.sol:DeployVRF --broadcast --rpc-url $RPC_URL
+contract DeployVRF is Script {
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        require(deployerPrivateKey != 0, "DeployVRF: PRIVATE_KEY env var required");
+
+        address deployerAddress = vm.addr(deployerPrivateKey);
+
+        // Owner defaults to deployer if VRF_OWNER is not set
+        address vrfOwner = vm.envOr("VRF_OWNER", deployerAddress);
+
+        console.log("=== DeployVRF: environment ===");
+        console.log("Deployer address:", deployerAddress);
+        console.log("VRF Owner:       ", vrfOwner);
+        console.log("Chain ID:        ", block.chainid);
+        console.log("==============================");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        NoosphereVRF vrf = new NoosphereVRF(vrfOwner);
+
+        vm.stopBroadcast();
+
+        console.log("=== DeployVRF: summary ===");
+        console.log("NoosphereVRF:", address(vrf));
+        console.log("Owner:       ", vrfOwner);
+        console.log("Epoch size:  ", vrf.EPOCH_SIZE());
+        console.log("==========================");
+    }
+}

--- a/scripts/RegisterEpoch.sol
+++ b/scripts/RegisterEpoch.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "forge-std/Script.sol";
+import {NoosphereVRF} from "@noosphere-evm/v1_0_0/vrf/NoosphereVRF.sol";
+
+contract RegisterEpoch is Script {
+    function run() external {
+        address vrfAddr = vm.envAddress("NOOSPHERE_VRF_ADDRESS");
+        uint256 epoch = vm.envUint("EPOCH");
+        bytes32 merkleRoot = vm.envBytes32("MERKLE_ROOT");
+
+        vm.startBroadcast();
+        NoosphereVRF(vrfAddr).registerEpoch(epoch, merkleRoot);
+        vm.stopBroadcast();
+
+        console.log("Registered epoch", epoch);
+        console.logBytes32(merkleRoot);
+    }
+}

--- a/src/v1_0_0/vrf/INoosphereVRF.sol
+++ b/src/v1_0_0/vrf/INoosphereVRF.sol
@@ -37,11 +37,17 @@ interface INoosphereVRF {
                         REQUEST LIFECYCLE
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice Assign a global request ID and record block number (called by VRFConsumer)
+    /// @notice Atomically reserve a global request ID (called by VRFConsumer before _requestCompute)
+    /// @dev Increments the global counter and records block number for 2-party entropy.
+    ///      Must be called before building container input to avoid race conditions.
+    /// @return requestId The globally unique request ID
+    function reserveRequestId() external returns (uint256 requestId);
+
+    /// @notice Bind a reserved request ID to a (subscriptionId, interval) pair for fulfillment routing
     /// @param subscriptionId The Noosphere subscription ID
     /// @param interval The interval assigned by _requestCompute()
-    /// @return requestId The globally unique request ID
-    function requestRandomValue(uint64 subscriptionId, uint32 interval) external returns (uint256 requestId);
+    /// @param requestId The previously reserved request ID
+    function bindRequest(uint64 subscriptionId, uint32 interval, uint256 requestId) external;
 
     /// @notice Verify Merkle proof and return random value (called by VRFConsumer callback)
     /// @param subscriptionId The Noosphere subscription ID

--- a/src/v1_0_0/vrf/INoosphereVRF.sol
+++ b/src/v1_0_0/vrf/INoosphereVRF.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.24;
+
+/// @title INoosphereVRF
+/// @notice Public interface for Noosphere VRF singleton
+/// @dev Manages epoch-based Merkle tree random values shared across all consumer dApps.
+///      Provides global request ID assignment, Merkle proof verification, and replay prevention.
+interface INoosphereVRF {
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event EpochRegistered(uint256 indexed epoch, bytes32 merkleRoot, uint256 size);
+    event EpochRunningLow(uint256 indexed epoch, uint256 remaining);
+    event RandomValueVerified(uint256 indexed requestId, bytes32 randomValue, bytes32 blockHash);
+    event RandomValueExpired(uint256 indexed requestId);
+    event ConsumerAdded(address indexed consumer);
+    event ConsumerRemoved(address indexed consumer);
+
+    /*//////////////////////////////////////////////////////////////
+                          EPOCH MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Register a Merkle root for an epoch (owner only, one-time per epoch)
+    function registerEpoch(uint256 epoch, bytes32 merkleRoot) external;
+
+    /// @notice Get the Merkle root for an epoch
+    function getEpochRoot(uint256 epoch) external view returns (bytes32);
+
+    /// @notice Get remaining slots in the current epoch
+    function getEpochRemaining() external view returns (uint256);
+
+    /// @notice Get the current epoch number
+    function getCurrentEpoch() external view returns (uint256);
+
+    /*//////////////////////////////////////////////////////////////
+                        REQUEST LIFECYCLE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Assign a global request ID and record block number (called by VRFConsumer)
+    /// @param subscriptionId The Noosphere subscription ID
+    /// @param interval The interval assigned by _requestCompute()
+    /// @return requestId The globally unique request ID
+    function requestRandomValue(uint64 subscriptionId, uint32 interval) external returns (uint256 requestId);
+
+    /// @notice Verify Merkle proof and return random value (called by VRFConsumer callback)
+    /// @param subscriptionId The Noosphere subscription ID
+    /// @param interval The interval from the callback
+    /// @param outputUri The raw output URI from the VRNG container
+    /// @return requestId The resolved request ID
+    /// @return randomValue The verified random value from the Merkle tree
+    /// @return blockHash The L2 block hash for 2-party entropy
+    /// @return expired Whether the request expired (blockHash unavailable)
+    function fulfillRandomValue(uint64 subscriptionId, uint32 interval, bytes calldata outputUri)
+        external
+        returns (uint256 requestId, bytes32 randomValue, bytes32 blockHash, bool expired);
+
+    /*//////////////////////////////////////////////////////////////
+                           VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Get the next request ID that will be assigned
+    function nextRequestId() external view returns (uint256);
+
+    /// @notice Check if a request has expired (block hash no longer available)
+    function isRequestExpired(uint256 requestId) external view returns (bool);
+
+    /// @notice Get the block number when a request was made
+    function getRequestBlock(uint256 requestId) external view returns (uint256);
+
+    /*//////////////////////////////////////////////////////////////
+                              CONFIG
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Number of random values per epoch
+    function EPOCH_SIZE() external view returns (uint256);
+
+    /// @notice Number of blocks before block hash becomes unavailable
+    function BLOCKHASH_TIMEOUT() external view returns (uint256);
+
+    /*//////////////////////////////////////////////////////////////
+                      CONSUMER MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Add an authorized consumer contract (owner only)
+    function addConsumer(address consumer) external;
+
+    /// @notice Remove an authorized consumer contract (owner only)
+    function removeConsumer(address consumer) external;
+
+    /// @notice Check if an address is an authorized consumer
+    function isAuthorizedConsumer(address consumer) external view returns (bool);
+}

--- a/src/v1_0_0/vrf/NoosphereVRF.sol
+++ b/src/v1_0_0/vrf/NoosphereVRF.sol
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.24;
+
+import {INoosphereVRF} from "./INoosphereVRF.sol";
+import {ITypeAndVersion} from "../interfaces/ITypeAndVersion.sol";
+import {MerkleProof} from "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+/// @dev Arbitrum ArbSys predeploy for L2 block number/hash
+interface ArbSys {
+    function arbBlockNumber() external view returns (uint256);
+    function arbBlockHash(uint256 arbBlockNum) external view returns (bytes32);
+}
+
+/// @title NoosphereVRF
+/// @notice Singleton contract for Noosphere VRF — shared across all consumer dApps.
+/// @dev Manages epoch roots, global request IDs, Merkle proof verification, and replay prevention.
+///      Deployed once per chain. Consumer dApps (NoosphereVRFConsumer) call this contract
+///      to request and fulfill random values.
+///
+///      Security model:
+///      - Random values are pre-committed via Merkle tree root (one-time, per epoch)
+///      - Each request is bound to a unique index in the epoch
+///      - Merkle proof ensures the random value matches the committed root
+///      - Block hash adds 2-party entropy (neither VRNG operator nor sequencer can predict both)
+///      - Replay prevention via delete-after-use pattern (Chainlink VRF Coordinator pattern)
+contract NoosphereVRF is INoosphereVRF, ITypeAndVersion {
+    /*//////////////////////////////////////////////////////////////
+                               CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    uint256 public constant BLOCKHASH_TIMEOUT = 256;
+    uint256 public constant EPOCH_SIZE = 1000;
+
+    /// @dev Arbitrum ArbSys predeploy at 0x64
+    ArbSys private constant ARB_SYS = ArbSys(address(0x0000000000000000000000000000000000000064));
+
+    /*//////////////////////////////////////////////////////////////
+                                STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Contract owner (can register epochs and manage consumers)
+    address public owner;
+
+    /// @notice Next request ID (monotonically increasing, global across all consumers)
+    uint256 private _nextRequestId;
+
+    /// @notice Merkle roots for each epoch
+    mapping(uint256 => bytes32) public epochRoots;
+
+    /// @notice Block number when each request was made (deleted after fulfillment)
+    mapping(uint256 => uint256) public requestBlocks;
+
+    /// @notice Callback routing: (subscriptionId, interval) → requestId+1
+    /// @dev Stored as requestId+1 so that 0 means "empty/fulfilled".
+    ///      Deleted after fulfillment for replay prevention + gas refund.
+    mapping(uint64 => mapping(uint32 => uint256)) private intervalToRequestId;
+
+    /// @notice Authorized consumer contracts (whitelist)
+    mapping(address => bool) public authorizedConsumers;
+
+    /*//////////////////////////////////////////////////////////////
+                               ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error NotOwner();
+    error NotAuthorizedConsumer();
+    error EpochAlreadyRegistered();
+    error EpochNotRegistered();
+    error AlreadyFulfilledOrInvalid();
+    error InvalidMerkleProof();
+
+    /*//////////////////////////////////////////////////////////////
+                              MODIFIERS
+    //////////////////////////////////////////////////////////////*/
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    modifier onlyConsumer() {
+        if (!authorizedConsumers[msg.sender]) revert NotAuthorizedConsumer();
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          EPOCH MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc INoosphereVRF
+    function registerEpoch(uint256 epoch, bytes32 merkleRoot) external onlyOwner {
+        if (epochRoots[epoch] != bytes32(0)) revert EpochAlreadyRegistered();
+        epochRoots[epoch] = merkleRoot;
+        emit EpochRegistered(epoch, merkleRoot, EPOCH_SIZE);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        REQUEST LIFECYCLE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc INoosphereVRF
+    function requestRandomValue(uint64 subscriptionId, uint32 interval)
+        external
+        onlyConsumer
+        returns (uint256 requestId)
+    {
+        requestId = _nextRequestId++;
+        uint256 epoch = requestId / EPOCH_SIZE;
+        if (epochRoots[epoch] == bytes32(0)) revert EpochNotRegistered();
+
+        // Record block number for 2-party entropy
+        requestBlocks[requestId] = ARB_SYS.arbBlockNumber();
+
+        // Store interval → requestId mapping (requestId+1 offset; 0 = empty)
+        intervalToRequestId[subscriptionId][interval] = requestId + 1;
+
+        // Warn when epoch is running low
+        uint256 usedInEpoch = requestId % EPOCH_SIZE + 1;
+        if (EPOCH_SIZE >= 100 && EPOCH_SIZE - usedInEpoch < 100) {
+            emit EpochRunningLow(epoch, EPOCH_SIZE - usedInEpoch);
+        }
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function fulfillRandomValue(uint64 subscriptionId, uint32 interval, bytes calldata outputUri)
+        external
+        onlyConsumer
+        returns (uint256 requestId, bytes32 randomValue, bytes32 blockHash, bool expired)
+    {
+        // ① Resolve requestId (replay prevention: delete after read)
+        uint256 stored = intervalToRequestId[subscriptionId][interval];
+        if (stored == 0) revert AlreadyFulfilledOrInvalid();
+        requestId = stored - 1;
+        delete intervalToRequestId[subscriptionId][interval]; // replay prevention + gas refund
+
+        // ② Decode packed hex from data URI
+        bytes32[] memory proof;
+        (randomValue, proof) = _decodeRevealOutput(outputUri);
+
+        // ③ Verify Merkle proof (leaf bound to index within epoch)
+        uint256 epoch = requestId / EPOCH_SIZE;
+        uint256 indexInEpoch = requestId % EPOCH_SIZE;
+        bytes32 leaf = keccak256(abi.encodePacked(indexInEpoch, randomValue));
+        if (!MerkleProof.verify(proof, epochRoots[epoch], leaf)) revert InvalidMerkleProof();
+
+        // ④ Get L2 blockhash for 2-party entropy (via ArbSys)
+        blockHash = ARB_SYS.arbBlockHash(requestBlocks[requestId]);
+        delete requestBlocks[requestId]; // gas refund — no longer needed
+
+        expired = (blockHash == bytes32(0));
+
+        if (expired) {
+            emit RandomValueExpired(requestId);
+        } else {
+            emit RandomValueVerified(requestId, randomValue, blockHash);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      CONSUMER MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc INoosphereVRF
+    function addConsumer(address consumer) external onlyOwner {
+        authorizedConsumers[consumer] = true;
+        emit ConsumerAdded(consumer);
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function removeConsumer(address consumer) external onlyOwner {
+        authorizedConsumers[consumer] = false;
+        emit ConsumerRemoved(consumer);
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function isAuthorizedConsumer(address consumer) external view returns (bool) {
+        return authorizedConsumers[consumer];
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc INoosphereVRF
+    function nextRequestId() external view returns (uint256) {
+        return _nextRequestId;
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function isRequestExpired(uint256 requestId) external view returns (bool) {
+        uint256 blockNum = requestBlocks[requestId];
+        if (blockNum == 0) return true; // already fulfilled or never existed
+        return ARB_SYS.arbBlockNumber() > blockNum + BLOCKHASH_TIMEOUT;
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function getRequestBlock(uint256 requestId) external view returns (uint256) {
+        return requestBlocks[requestId];
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function getEpochRoot(uint256 epoch) external view returns (bytes32) {
+        return epochRoots[epoch];
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function getEpochRemaining() external view returns (uint256) {
+        uint256 currentEpoch = _nextRequestId / EPOCH_SIZE;
+        uint256 usedInEpoch = _nextRequestId % EPOCH_SIZE;
+        if (epochRoots[currentEpoch] == bytes32(0)) return 0;
+        return EPOCH_SIZE - usedInEpoch;
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function getCurrentEpoch() external view returns (uint256) {
+        return _nextRequestId / EPOCH_SIZE;
+    }
+
+    /// @notice Transfer ownership
+    function transferOwnership(address newOwner) external onlyOwner {
+        owner = newOwner;
+    }
+
+    /// @inheritdoc ITypeAndVersion
+    function typeAndVersion() external pure returns (string memory) {
+        return "NoosphereVRF_v1.0.0";
+    }
+
+    /*//////////////////////////////////////////////////////////////
+            RAW BYTES DECODE (DATA URI → randomValue + proof)
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Decode reveal output from data URI: base64(raw bytes) → (randomValue, proof[])
+    /// @dev Raw bytes format: randomValue(32 bytes) + proof[0](32 bytes) + ...
+    ///      Agent wraps container output: data:;base64,<base64(base64(rawBytes))>
+    ///      This function does double base64 decode in a single assembly block
+    ///      with one shared lookup table for maximum gas efficiency.
+    function _decodeRevealOutput(bytes calldata uri)
+        internal
+        pure
+        returns (bytes32 randomValue, bytes32[] memory proof)
+    {
+        assembly {
+            // ── Build base64 lookup table (256 bytes) ──
+            let table := mload(0x40)
+            // Zero-fill 256 bytes (8 × 32-byte words)
+            for { let i := 0 } lt(i, 8) { i := add(i, 1) } {
+                mstore(add(table, mul(i, 32)), 0)
+            }
+            // A-Z → 0-25
+            for { let i := 0 } lt(i, 26) { i := add(i, 1) } { mstore8(add(table, add(65, i)), i) }
+            // a-z → 26-51
+            for { let i := 0 } lt(i, 26) { i := add(i, 1) } { mstore8(add(table, add(97, i)), add(26, i)) }
+            // 0-9 → 52-61
+            for { let i := 0 } lt(i, 10) { i := add(i, 1) } { mstore8(add(table, add(48, i)), add(52, i)) }
+            // + → 62, / → 63
+            mstore8(add(table, 43), 62)
+            mstore8(add(table, 47), 63)
+
+            // ── Step 1: Copy outer base64 from calldata to memory ──
+            // URI format: "data:;base64," (13 bytes) + base64 content
+            let outerLen := sub(uri.length, 13)
+            let outerSrc := add(uri.offset, 13)
+            // Allocate memory for outer base64 data
+            let outerMem := add(table, 256)
+            calldatacopy(outerMem, outerSrc, outerLen)
+
+            // ── Step 2: Decode outer base64 → inner base64 string ──
+            let outerDecLen := mul(div(outerLen, 4), 3)
+            // Check padding
+            let outerEnd := add(outerMem, sub(outerLen, 1))
+            if eq(byte(0, mload(outerEnd)), 0x3d) { outerDecLen := sub(outerDecLen, 1) }
+            if eq(byte(0, mload(sub(outerEnd, 1))), 0x3d) { outerDecLen := sub(outerDecLen, 1) }
+
+            let innerB64 := add(outerMem, outerLen) // place after outer data (reuse memory)
+            let rp := innerB64
+            let dp := outerMem
+            let dpEnd := add(dp, outerLen)
+            for {} lt(dp, dpEnd) { dp := add(dp, 4) } {
+                let a := byte(0, mload(add(table, byte(0, mload(dp)))))
+                let b := byte(0, mload(add(table, byte(0, mload(add(dp, 1))))))
+                let c := byte(0, mload(add(table, byte(0, mload(add(dp, 2))))))
+                let d := byte(0, mload(add(table, byte(0, mload(add(dp, 3))))))
+                let triple := or(or(shl(18, a), shl(12, b)), or(shl(6, c), d))
+                mstore8(rp, shr(16, triple))
+                mstore8(add(rp, 1), and(shr(8, triple), 0xFF))
+                mstore8(add(rp, 2), and(triple, 0xFF))
+                rp := add(rp, 3)
+            }
+
+            // ── Step 3: Decode inner base64 → raw bytes ──
+            let innerLen := outerDecLen
+            let innerDecLen := mul(div(innerLen, 4), 3)
+            let innerEnd := add(innerB64, sub(innerLen, 1))
+            if eq(byte(0, mload(innerEnd)), 0x3d) { innerDecLen := sub(innerDecLen, 1) }
+            if eq(byte(0, mload(sub(innerEnd, 1))), 0x3d) { innerDecLen := sub(innerDecLen, 1) }
+
+            let rawBytes := add(innerB64, innerLen)
+            rp := rawBytes
+            dp := innerB64
+            dpEnd := add(dp, innerLen)
+            for {} lt(dp, dpEnd) { dp := add(dp, 4) } {
+                let a := byte(0, mload(add(table, byte(0, mload(dp)))))
+                let b := byte(0, mload(add(table, byte(0, mload(add(dp, 1))))))
+                let c := byte(0, mload(add(table, byte(0, mload(add(dp, 2))))))
+                let d := byte(0, mload(add(table, byte(0, mload(add(dp, 3))))))
+                let triple := or(or(shl(18, a), shl(12, b)), or(shl(6, c), d))
+                mstore8(rp, shr(16, triple))
+                mstore8(add(rp, 1), and(shr(8, triple), 0xFF))
+                mstore8(add(rp, 2), and(triple, 0xFF))
+                rp := add(rp, 3)
+            }
+
+            // ── Step 4: Extract randomValue (first 32 bytes) ──
+            // rawBytes is NOT 32-byte aligned for mload, so copy to aligned location
+            let aligned := add(rawBytes, innerDecLen)
+            // Copy 32 bytes for randomValue
+            for { let i := 0 } lt(i, 32) { i := add(i, 1) } {
+                mstore8(add(aligned, i), byte(0, mload(add(rawBytes, i))))
+            }
+            randomValue := mload(aligned)
+
+            // ── Step 5: Build proof array ──
+            if lt(innerDecLen, 32) { revert(0, 0) }
+            let proofBytes := sub(innerDecLen, 32)
+            let proofCount := div(proofBytes, 32)
+
+            // Allocate proof array
+            proof := add(aligned, 32)
+            mstore(proof, proofCount)
+            let proofData := add(proof, 32)
+            let rawProofStart := add(rawBytes, 32)
+            for { let i := 0 } lt(i, proofCount) { i := add(i, 1) } {
+                let elemDst := add(proofData, mul(i, 32))
+                let elemSrc := add(rawProofStart, mul(i, 32))
+                // byte-by-byte copy for unaligned source
+                for { let j := 0 } lt(j, 32) { j := add(j, 1) } {
+                    mstore8(add(elemDst, j), byte(0, mload(add(elemSrc, j))))
+                }
+            }
+
+            // Update free memory pointer
+            mstore(0x40, add(proofData, mul(proofCount, 32)))
+        }
+    }
+}

--- a/src/v1_0_0/vrf/NoosphereVRF.sol
+++ b/src/v1_0_0/vrf/NoosphereVRF.sol
@@ -67,7 +67,9 @@ contract NoosphereVRF is INoosphereVRF, ITypeAndVersion {
     error EpochAlreadyRegistered();
     error EpochNotRegistered();
     error AlreadyFulfilledOrInvalid();
+    error InvalidRequestId();
     error InvalidMerkleProof();
+    error InvalidOutputData();
 
     /*//////////////////////////////////////////////////////////////
                               MODIFIERS
@@ -107,11 +109,7 @@ contract NoosphereVRF is INoosphereVRF, ITypeAndVersion {
     //////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc INoosphereVRF
-    function requestRandomValue(uint64 subscriptionId, uint32 interval)
-        external
-        onlyConsumer
-        returns (uint256 requestId)
-    {
+    function reserveRequestId() external onlyConsumer returns (uint256 requestId) {
         requestId = _nextRequestId++;
         uint256 epoch = requestId / EPOCH_SIZE;
         if (epochRoots[epoch] == bytes32(0)) revert EpochNotRegistered();
@@ -119,14 +117,17 @@ contract NoosphereVRF is INoosphereVRF, ITypeAndVersion {
         // Record block number for 2-party entropy
         requestBlocks[requestId] = ARB_SYS.arbBlockNumber();
 
-        // Store interval → requestId mapping (requestId+1 offset; 0 = empty)
-        intervalToRequestId[subscriptionId][interval] = requestId + 1;
-
         // Warn when epoch is running low
         uint256 usedInEpoch = requestId % EPOCH_SIZE + 1;
         if (EPOCH_SIZE >= 100 && EPOCH_SIZE - usedInEpoch < 100) {
             emit EpochRunningLow(epoch, EPOCH_SIZE - usedInEpoch);
         }
+    }
+
+    /// @inheritdoc INoosphereVRF
+    function bindRequest(uint64 subscriptionId, uint32 interval, uint256 requestId) external onlyConsumer {
+        if (requestBlocks[requestId] == 0) revert InvalidRequestId();
+        intervalToRequestId[subscriptionId][interval] = requestId + 1;
     }
 
     /// @inheritdoc INoosphereVRF
@@ -248,6 +249,7 @@ contract NoosphereVRF is INoosphereVRF, ITypeAndVersion {
         pure
         returns (bytes32 randomValue, bytes32[] memory proof)
     {
+        uint256 decodedLen;
         assembly {
             // ── Build base64 lookup table (256 bytes) ──
             let table := mload(0x40)
@@ -319,36 +321,37 @@ contract NoosphereVRF is INoosphereVRF, ITypeAndVersion {
                 rp := add(rp, 3)
             }
 
+            // Store decoded length for post-assembly validation
+            decodedLen := innerDecLen
+
             // ── Step 4: Extract randomValue (first 32 bytes) ──
-            // rawBytes is NOT 32-byte aligned for mload, so copy to aligned location
-            let aligned := add(rawBytes, innerDecLen)
-            // Copy 32 bytes for randomValue
-            for { let i := 0 } lt(i, 32) { i := add(i, 1) } {
-                mstore8(add(aligned, i), byte(0, mload(add(rawBytes, i))))
-            }
-            randomValue := mload(aligned)
+            // EVM mload works at any memory offset — no alignment copy needed
+            randomValue := mload(rawBytes)
 
             // ── Step 5: Build proof array ──
-            if lt(innerDecLen, 32) { revert(0, 0) }
-            let proofBytes := sub(innerDecLen, 32)
-            let proofCount := div(proofBytes, 32)
+            let proofBytes := 0
+            let proofCount := 0
+            if gt(innerDecLen, 31) {
+                proofBytes := sub(innerDecLen, 32)
+                proofCount := div(proofBytes, 32)
+            }
 
-            // Allocate proof array
-            proof := add(aligned, 32)
+            // Allocate proof array after raw data region
+            let proofArrayStart := add(rawBytes, innerDecLen)
+            proof := proofArrayStart
             mstore(proof, proofCount)
             let proofData := add(proof, 32)
             let rawProofStart := add(rawBytes, 32)
+            // Single mload+mstore per 32-byte element (replaces 32x byte-by-byte copy)
             for { let i := 0 } lt(i, proofCount) { i := add(i, 1) } {
-                let elemDst := add(proofData, mul(i, 32))
-                let elemSrc := add(rawProofStart, mul(i, 32))
-                // byte-by-byte copy for unaligned source
-                for { let j := 0 } lt(j, 32) { j := add(j, 1) } {
-                    mstore8(add(elemDst, j), byte(0, mload(add(elemSrc, j))))
-                }
+                mstore(add(proofData, mul(i, 32)), mload(add(rawProofStart, mul(i, 32))))
             }
 
             // Update free memory pointer
             mstore(0x40, add(proofData, mul(proofCount, 32)))
         }
+
+        // Validate decoded output has at least 32 bytes (randomValue)
+        if (decodedLen < 32) revert InvalidOutputData();
     }
 }

--- a/src/v1_0_0/vrf/NoosphereVRFConsumer.sol
+++ b/src/v1_0_0/vrf/NoosphereVRFConsumer.sol
@@ -43,6 +43,7 @@ abstract contract NoosphereVRFConsumer is TransientComputeClient, Delegator {
     //////////////////////////////////////////////////////////////*/
 
     event SubscriptionCreated(uint64 indexed subscriptionId, address indexed owner);
+    event SubscriptionCancelled(uint64 indexed subscriptionId, address indexed owner);
 
     /*//////////////////////////////////////////////////////////////
                                ERRORS
@@ -97,6 +98,21 @@ abstract contract NoosphereVRFConsumer is TransientComputeClient, Delegator {
     function cancelSubscription(uint64 subscriptionId) external {
         if (subscriptionOwner[subscriptionId] != msg.sender) revert NotSubscriptionOwner();
         _cancelComputeSubscription(subscriptionId);
+
+        // Clean up: remove from userSubscriptions array (swap-and-pop)
+        uint64[] storage subs = userSubscriptions[msg.sender];
+        for (uint256 i = 0; i < subs.length; i++) {
+            if (subs[i] == subscriptionId) {
+                subs[i] = subs[subs.length - 1];
+                subs.pop();
+                break;
+            }
+        }
+
+        // Clear ownership mapping
+        delete subscriptionOwner[subscriptionId];
+
+        emit SubscriptionCancelled(subscriptionId, msg.sender);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -104,21 +120,20 @@ abstract contract NoosphereVRFConsumer is TransientComputeClient, Delegator {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice Request a random value via the Noosphere VRF pipeline
-    /// @dev Sends compute request to VRNG container, then registers with NoosphereVRF singleton.
-    ///      Uses Peek+Commit pattern: reads nextRequestId first, includes it in container input,
-    ///      then registers with NoosphereVRF which assigns the actual requestId.
+    /// @dev Reserve-then-bind pattern: atomically reserves requestId first to avoid race conditions,
+    ///      then uses the actual ID in the container input, then binds the interval for fulfillment routing.
     /// @param subscriptionId The subscription to use for VRNG
     /// @return requestId The globally unique request ID assigned by NoosphereVRF
     function _requestRandomValue(uint64 subscriptionId) internal returns (uint256 requestId) {
-        // Peek at the next request ID (for container input)
-        uint256 expectedId = noosphereVRF.nextRequestId();
+        // Atomically reserve request ID (no race condition — counter incremented in same tx)
+        requestId = noosphereVRF.reserveRequestId();
 
-        // Send compute request to VRNG container
-        bytes memory input = abi.encodePacked('{"action":"reveal","game_id":', _uint2str(expectedId), "}");
+        // Send compute request to VRNG container with the actual (not peeked) request ID
+        bytes memory input = abi.encodePacked('{"action":"reveal","game_id":', _uint2str(requestId), "}");
         (, Commitment memory commitment) = _requestCompute(subscriptionId, input);
 
-        // Register with NoosphereVRF (assigns requestId, records block number)
-        requestId = noosphereVRF.requestRandomValue(subscriptionId, commitment.interval);
+        // Bind interval to the reserved request ID for fulfillment routing
+        noosphereVRF.bindRequest(subscriptionId, commitment.interval, requestId);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -165,8 +180,22 @@ abstract contract NoosphereVRFConsumer is TransientComputeClient, Delegator {
                            VIEW FUNCTIONS
     //////////////////////////////////////////////////////////////*/
 
-    function getUserSubscriptions(address user) external view returns (uint64[] memory) {
-        return userSubscriptions[user];
+    function getUserSubscriptions(address user, uint256 offset, uint256 limit) external view returns (uint64[] memory) {
+        uint64[] storage subs = userSubscriptions[user];
+        uint256 total = subs.length;
+        if (offset >= total) return new uint64[](0);
+        uint256 end = offset + limit;
+        if (end > total) end = total;
+        uint256 count = end - offset;
+        uint64[] memory result = new uint64[](count);
+        for (uint256 i = 0; i < count; i++) {
+            result[i] = subs[offset + i];
+        }
+        return result;
+    }
+
+    function getUserSubscriptionCount(address user) external view returns (uint256) {
+        return userSubscriptions[user].length;
     }
 
     function getSubscriptionOwner(uint64 subscriptionId) external view returns (address) {

--- a/src/v1_0_0/vrf/NoosphereVRFConsumer.sol
+++ b/src/v1_0_0/vrf/NoosphereVRFConsumer.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.24;
+
+import {Commitment} from "../types/Commitment.sol";
+import {PayloadData} from "../types/PayloadData.sol";
+import {TransientComputeClient} from "../client/TransientComputeClient.sol";
+import {Delegator} from "../utility/Delegator.sol";
+import {INoosphereVRF} from "./INoosphereVRF.sol";
+
+/// @title NoosphereVRFConsumer
+/// @notice Abstract contract for dApps that consume Noosphere VRF random values.
+/// @dev Inherit this contract and implement the two virtual hooks:
+///      - `_onRandomValueReceived(requestId, randomValue, blockHash)` — called on successful verification
+///      - `_onRandomValueExpired(requestId)` — called when blockhash is no longer available
+///
+///      Flow:
+///      1. dApp calls `_requestRandomValue(subscriptionId)` — sends compute request + registers with NoosphereVRF
+///      2. Node executes VRNG container, delivers result via Noosphere pipeline
+///      3. `_receiveCompute()` delegates proof verification to NoosphereVRF singleton
+///      4. NoosphereVRF verifies Merkle proof, returns random value + block hash
+///      5. Appropriate hook is called based on expiry status
+///
+///      Subscription management (createSubscription, cancelSubscription) is also provided.
+abstract contract NoosphereVRFConsumer is TransientComputeClient, Delegator {
+    /*//////////////////////////////////////////////////////////////
+                                STORAGE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice The NoosphereVRF singleton (shared across all consumers)
+    INoosphereVRF public immutable noosphereVRF;
+
+    /// @notice Subscription ownership
+    mapping(uint64 => address) public subscriptionOwner;
+
+    /// @notice User → subscription IDs
+    mapping(address => uint64[]) private userSubscriptions;
+
+    /// @notice Contract owner
+    address public owner;
+
+    /*//////////////////////////////////////////////////////////////
+                                EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    event SubscriptionCreated(uint64 indexed subscriptionId, address indexed owner);
+
+    /*//////////////////////////////////////////////////////////////
+                               ERRORS
+    //////////////////////////////////////////////////////////////*/
+
+    error NotOwner();
+    error NotSubscriptionOwner();
+
+    /*//////////////////////////////////////////////////////////////
+                              MODIFIERS
+    //////////////////////////////////////////////////////////////*/
+
+    modifier onlyOwner() {
+        if (msg.sender != owner) revert NotOwner();
+        _;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                              CONSTRUCTOR
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(address router, address signer, address _noosphereVRF)
+        TransientComputeClient(router)
+        Delegator(signer)
+    {
+        noosphereVRF = INoosphereVRF(_noosphereVRF);
+        owner = msg.sender;
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        SUBSCRIPTION MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    function createSubscription(
+        string memory containerId,
+        bool useDeliveryInbox,
+        address feeToken,
+        uint256 feeAmount,
+        address wallet,
+        address verifier,
+        bytes32 routeId
+    ) external returns (uint64) {
+        uint64 subscriptionId = _createComputeSubscription(
+            containerId, useDeliveryInbox, feeToken, feeAmount, wallet, verifier, routeId
+        );
+        subscriptionOwner[subscriptionId] = msg.sender;
+        userSubscriptions[msg.sender].push(subscriptionId);
+        emit SubscriptionCreated(subscriptionId, msg.sender);
+        return subscriptionId;
+    }
+
+    function cancelSubscription(uint64 subscriptionId) external {
+        if (subscriptionOwner[subscriptionId] != msg.sender) revert NotSubscriptionOwner();
+        _cancelComputeSubscription(subscriptionId);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         REQUEST RANDOM VALUE
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Request a random value via the Noosphere VRF pipeline
+    /// @dev Sends compute request to VRNG container, then registers with NoosphereVRF singleton.
+    ///      Uses Peek+Commit pattern: reads nextRequestId first, includes it in container input,
+    ///      then registers with NoosphereVRF which assigns the actual requestId.
+    /// @param subscriptionId The subscription to use for VRNG
+    /// @return requestId The globally unique request ID assigned by NoosphereVRF
+    function _requestRandomValue(uint64 subscriptionId) internal returns (uint256 requestId) {
+        // Peek at the next request ID (for container input)
+        uint256 expectedId = noosphereVRF.nextRequestId();
+
+        // Send compute request to VRNG container
+        bytes memory input = abi.encodePacked('{"action":"reveal","game_id":', _uint2str(expectedId), "}");
+        (, Commitment memory commitment) = _requestCompute(subscriptionId, input);
+
+        // Register with NoosphereVRF (assigns requestId, records block number)
+        requestId = noosphereVRF.requestRandomValue(subscriptionId, commitment.interval);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                      CALLBACK (VRF VERIFICATION)
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Callback from Noosphere compute pipeline. Delegates proof verification to NoosphereVRF.
+    function _receiveCompute(
+        uint64 subscriptionId,
+        uint32 interval,
+        bool,
+        address,
+        PayloadData calldata,
+        PayloadData calldata output,
+        PayloadData calldata,
+        bytes32
+    ) internal override {
+        // Delegate all verification to NoosphereVRF singleton
+        (uint256 requestId, bytes32 randomValue, bytes32 blockHash, bool expired) =
+            noosphereVRF.fulfillRandomValue(subscriptionId, interval, output.uri);
+
+        if (expired) {
+            _onRandomValueExpired(requestId);
+        } else {
+            _onRandomValueReceived(requestId, randomValue, blockHash);
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          VIRTUAL HOOKS
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Called when a random value is successfully received and verified
+    /// @param requestId The globally unique request ID
+    /// @param randomValue The verified random value from the Merkle tree
+    /// @param blockHash The L2 block hash for 2-party entropy
+    function _onRandomValueReceived(uint256 requestId, bytes32 randomValue, bytes32 blockHash) internal virtual;
+
+    /// @notice Called when a request has expired (blockhash no longer available)
+    /// @param requestId The globally unique request ID
+    function _onRandomValueExpired(uint256 requestId) internal virtual;
+
+    /*//////////////////////////////////////////////////////////////
+                           VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function getUserSubscriptions(address user) external view returns (uint64[] memory) {
+        return userSubscriptions[user];
+    }
+
+    function getSubscriptionOwner(uint64 subscriptionId) external view returns (address) {
+        return subscriptionOwner[subscriptionId];
+    }
+
+    function updateSigner(address newSigner) external onlyOwner {
+        _updateSigner(newSigner);
+    }
+
+    function getRouterAddress() external view returns (address) {
+        return address(_getRouter());
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          HELPER FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function _uint2str(uint256 value) internal pure returns (string memory) {
+        if (value == 0) return "0";
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/test/NoosphereVRF.t.sol
+++ b/test/NoosphereVRF.t.sol
@@ -1,0 +1,756 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {NoosphereVRF} from "../src/v1_0_0/vrf/NoosphereVRF.sol";
+import {INoosphereVRF} from "../src/v1_0_0/vrf/INoosphereVRF.sol";
+import {NoosphereVRFConsumer} from "../src/v1_0_0/vrf/NoosphereVRFConsumer.sol";
+import {Commitment} from "../src/v1_0_0/types/Commitment.sol";
+import {PayloadData} from "../src/v1_0_0/types/PayloadData.sol";
+
+/*//////////////////////////////////////////////////////////////
+                            MOCKS
+//////////////////////////////////////////////////////////////*/
+
+/// @dev Minimal router mock — returns sequential subscription IDs
+contract MockRouter {
+    uint64 private _nextSubId = 1;
+
+    function createComputeSubscription(
+        string memory,
+        uint32,
+        uint32,
+        bool,
+        address,
+        uint256,
+        address,
+        address,
+        bytes32
+    ) external returns (uint64) {
+        return _nextSubId++;
+    }
+
+    function cancelComputeSubscription(uint64) external {}
+}
+
+/// @dev Concrete VRF consumer for testing
+contract TestVRFConsumer is NoosphereVRFConsumer {
+    constructor(address router, address signer, address vrfAddr) NoosphereVRFConsumer(router, signer, vrfAddr) {}
+
+    function _onRandomValueReceived(uint256, bytes32, bytes32) internal override {}
+    function _onRandomValueExpired(uint256) internal override {}
+
+    function typeAndVersion() external pure override returns (string memory) {
+        return "TestVRFConsumer_v1.0.0";
+    }
+}
+
+/*//////////////////////////////////////////////////////////////
+            NoosphereVRF — CORE FUNCTIONALITY TESTS
+//////////////////////////////////////////////////////////////*/
+
+contract NoosphereVRFCoreTest is Test {
+    NoosphereVRF public vrf;
+    address public constant OWNER = address(0x1);
+    address public constant CONSUMER = address(0x2);
+
+    // 4-leaf Merkle tree test vectors
+    bytes32 constant RV0 = bytes32(uint256(0x1111111111111111111111111111111111111111111111111111111111111111));
+    bytes32 constant RV1 = bytes32(uint256(0x2222222222222222222222222222222222222222222222222222222222222222));
+    bytes32 constant RV2 = bytes32(uint256(0x3333333333333333333333333333333333333333333333333333333333333333));
+    bytes32 constant RV3 = bytes32(uint256(0x4444444444444444444444444444444444444444444444444444444444444444));
+
+    bytes32 public leaf0;
+    bytes32 public leaf1;
+    bytes32 public leaf2;
+    bytes32 public leaf3;
+    bytes32 public node01;
+    bytes32 public node23;
+    bytes32 public merkleRoot;
+
+    function setUp() public {
+        // Mock ArbSys predeploy at 0x64
+        vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockNumber()"), abi.encode(uint256(100)));
+        vm.mockCall(
+            address(0x64),
+            abi.encodeWithSignature("arbBlockHash(uint256)"),
+            abi.encode(keccak256("block100"))
+        );
+
+        vrf = new NoosphereVRF(OWNER);
+
+        // Build 4-leaf Merkle tree (OZ commutative hash)
+        leaf0 = keccak256(abi.encodePacked(uint256(0), RV0));
+        leaf1 = keccak256(abi.encodePacked(uint256(1), RV1));
+        leaf2 = keccak256(abi.encodePacked(uint256(2), RV2));
+        leaf3 = keccak256(abi.encodePacked(uint256(3), RV3));
+        node01 = _commHash(leaf0, leaf1);
+        node23 = _commHash(leaf2, leaf3);
+        merkleRoot = _commHash(node01, node23);
+
+        vm.startPrank(OWNER);
+        vrf.registerEpoch(0, merkleRoot);
+        vrf.addConsumer(CONSUMER);
+        vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                         EPOCH MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    function test_registerEpoch() public view {
+        assertEq(vrf.getEpochRoot(0), merkleRoot);
+    }
+
+    function test_registerEpoch_emitsEvent() public {
+        vm.prank(OWNER);
+        vm.expectEmit(true, false, false, true);
+        emit INoosphereVRF.EpochRegistered(1, bytes32(uint256(0xBEEF)), 1000);
+        vrf.registerEpoch(1, bytes32(uint256(0xBEEF)));
+    }
+
+    function test_registerEpoch_duplicate_reverts() public {
+        vm.prank(OWNER);
+        vm.expectRevert(NoosphereVRF.EpochAlreadyRegistered.selector);
+        vrf.registerEpoch(0, bytes32(uint256(0xBEEF)));
+    }
+
+    function test_registerEpoch_onlyOwner() public {
+        vm.prank(address(0x999));
+        vm.expectRevert(NoosphereVRF.NotOwner.selector);
+        vrf.registerEpoch(1, bytes32(uint256(0xBEEF)));
+    }
+
+    function test_getCurrentEpoch() public view {
+        assertEq(vrf.getCurrentEpoch(), 0);
+    }
+
+    function test_getEpochRemaining() public {
+        assertEq(vrf.getEpochRemaining(), 1000);
+
+        vm.prank(CONSUMER);
+        vrf.reserveRequestId();
+        assertEq(vrf.getEpochRemaining(), 999);
+    }
+
+    function test_getEpochRemaining_noEpoch() public {
+        NoosphereVRF freshVrf = new NoosphereVRF(address(this));
+        assertEq(freshVrf.getEpochRemaining(), 0);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       CONSUMER MANAGEMENT
+    //////////////////////////////////////////////////////////////*/
+
+    function test_addConsumer() public {
+        address newConsumer = address(0x50);
+        assertFalse(vrf.isAuthorizedConsumer(newConsumer));
+
+        vm.prank(OWNER);
+        vm.expectEmit(true, false, false, false);
+        emit INoosphereVRF.ConsumerAdded(newConsumer);
+        vrf.addConsumer(newConsumer);
+
+        assertTrue(vrf.isAuthorizedConsumer(newConsumer));
+    }
+
+    function test_removeConsumer() public {
+        assertTrue(vrf.isAuthorizedConsumer(CONSUMER));
+
+        vm.prank(OWNER);
+        vm.expectEmit(true, false, false, false);
+        emit INoosphereVRF.ConsumerRemoved(CONSUMER);
+        vrf.removeConsumer(CONSUMER);
+
+        assertFalse(vrf.isAuthorizedConsumer(CONSUMER));
+    }
+
+    function test_addConsumer_onlyOwner() public {
+        vm.prank(address(0x999));
+        vm.expectRevert(NoosphereVRF.NotOwner.selector);
+        vrf.addConsumer(address(0x50));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                           OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
+
+    function test_transferOwnership() public {
+        address newOwner = address(0x99);
+        vm.prank(OWNER);
+        vrf.transferOwnership(newOwner);
+        assertEq(vrf.owner(), newOwner);
+
+        // Old owner can no longer act
+        vm.prank(OWNER);
+        vm.expectRevert(NoosphereVRF.NotOwner.selector);
+        vrf.addConsumer(address(0x50));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                          CONSTANTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_constants() public view {
+        assertEq(vrf.BLOCKHASH_TIMEOUT(), 256);
+        assertEq(vrf.EPOCH_SIZE(), 1000);
+    }
+
+    function test_typeAndVersion() public view {
+        assertEq(vrf.typeAndVersion(), "NoosphereVRF_v1.0.0");
+    }
+
+    /*//////////////////////////////////////////////////////////////
+               reserveRequestId + bindRequest (Fix #1)
+    //////////////////////////////////////////////////////////////*/
+
+    function test_reserveRequestId_incrementsCounter() public {
+        vm.startPrank(CONSUMER);
+        uint256 id0 = vrf.reserveRequestId();
+        uint256 id1 = vrf.reserveRequestId();
+        vm.stopPrank();
+
+        assertEq(id0, 0);
+        assertEq(id1, 1);
+        assertEq(vrf.nextRequestId(), 2);
+    }
+
+    function test_reserveRequestId_recordsBlock() public {
+        vm.prank(CONSUMER);
+        uint256 id = vrf.reserveRequestId();
+        assertEq(vrf.getRequestBlock(id), 100);
+    }
+
+    function test_reserveRequestId_unauthorized_reverts() public {
+        vm.prank(address(0x999));
+        vm.expectRevert(NoosphereVRF.NotAuthorizedConsumer.selector);
+        vrf.reserveRequestId();
+    }
+
+    function test_reserveRequestId_noEpoch_reverts() public {
+        NoosphereVRF freshVrf = new NoosphereVRF(address(this));
+        freshVrf.addConsumer(CONSUMER);
+
+        vm.prank(CONSUMER);
+        vm.expectRevert(NoosphereVRF.EpochNotRegistered.selector);
+        freshVrf.reserveRequestId();
+    }
+
+    function test_bindRequest_succeeds() public {
+        vm.prank(CONSUMER);
+        uint256 id = vrf.reserveRequestId();
+
+        vm.prank(CONSUMER);
+        vrf.bindRequest(1, 42, id);
+    }
+
+    function test_bindRequest_invalidRequestId_reverts() public {
+        vm.prank(CONSUMER);
+        vm.expectRevert(NoosphereVRF.InvalidRequestId.selector);
+        vrf.bindRequest(1, 42, 999);
+    }
+
+    function test_bindRequest_unauthorized_reverts() public {
+        vm.prank(CONSUMER);
+        uint256 id = vrf.reserveRequestId();
+
+        vm.prank(address(0x999));
+        vm.expectRevert(NoosphereVRF.NotAuthorizedConsumer.selector);
+        vrf.bindRequest(1, 42, id);
+    }
+
+    function test_reserveAndBind_atomicFlow() public {
+        vm.startPrank(CONSUMER);
+        uint256 id = vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, id);
+        vm.stopPrank();
+
+        assertEq(id, 0);
+        assertEq(vrf.getRequestBlock(id), 100);
+    }
+
+    function test_multipleConsumers_noIdClash() public {
+        address consumer2 = address(0x3);
+        vm.prank(OWNER);
+        vrf.addConsumer(consumer2);
+
+        vm.prank(CONSUMER);
+        uint256 id1 = vrf.reserveRequestId();
+
+        vm.prank(consumer2);
+        uint256 id2 = vrf.reserveRequestId();
+
+        assertEq(id1, 0);
+        assertEq(id2, 1);
+    }
+
+    function test_interleavedReserveAndBind() public {
+        address consumer2 = address(0x3);
+        vm.prank(OWNER);
+        vrf.addConsumer(consumer2);
+
+        vm.prank(CONSUMER);
+        uint256 idA = vrf.reserveRequestId();
+
+        vm.prank(consumer2);
+        uint256 idB = vrf.reserveRequestId();
+
+        // Both bind — each gets their own reserved ID
+        vm.prank(CONSUMER);
+        vrf.bindRequest(10, 1, idA);
+
+        vm.prank(consumer2);
+        vrf.bindRequest(20, 1, idB);
+
+        assertEq(idA, 0);
+        assertEq(idB, 1);
+    }
+
+    function test_epochRunningLow_emitsAt100Remaining() public {
+        vm.startPrank(CONSUMER);
+        for (uint256 i = 0; i < 900; i++) {
+            vrf.reserveRequestId();
+        }
+
+        // Request #900: usedInEpoch=901, remaining=99 → emits
+        vm.expectEmit(true, false, false, true);
+        emit INoosphereVRF.EpochRunningLow(0, 99);
+        vrf.reserveRequestId();
+        vm.stopPrank();
+    }
+
+    /*//////////////////////////////////////////////////////////////
+             fulfillRandomValue — FULL FLOW
+    //////////////////////////////////////////////////////////////*/
+
+    function test_fulfillRandomValue_fullFlow() public {
+        vm.startPrank(CONSUMER);
+        uint256 requestId = vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, requestId);
+
+        // Build data URI with proof for leaf0: [leaf1, node23]
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf1, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+
+        (uint256 retId, bytes32 retRv, bytes32 retBlockHash, bool expired) = vrf.fulfillRandomValue(1, 7, uri);
+        vm.stopPrank();
+
+        assertEq(retId, requestId);
+        assertEq(retRv, RV0);
+        assertTrue(retBlockHash != bytes32(0));
+        assertFalse(expired);
+    }
+
+    function test_fulfillRandomValue_emitsEvent() public {
+        vm.startPrank(CONSUMER);
+        uint256 requestId = vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, requestId);
+
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf1, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+
+        vm.expectEmit(true, false, false, true);
+        emit INoosphereVRF.RandomValueVerified(requestId, RV0, keccak256("block100"));
+        vrf.fulfillRandomValue(1, 7, uri);
+        vm.stopPrank();
+    }
+
+    function test_fulfillRandomValue_replayReverts() public {
+        vm.startPrank(CONSUMER);
+        vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, 0);
+
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf1, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+
+        vrf.fulfillRandomValue(1, 7, uri);
+
+        vm.expectRevert(NoosphereVRF.AlreadyFulfilledOrInvalid.selector);
+        vrf.fulfillRandomValue(1, 7, uri);
+        vm.stopPrank();
+    }
+
+    function test_fulfillRandomValue_invalidProof_reverts() public {
+        vm.startPrank(CONSUMER);
+        vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, 0);
+
+        // Wrong proof: leaf2 instead of leaf1
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf2, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+
+        vm.expectRevert(NoosphereVRF.InvalidMerkleProof.selector);
+        vrf.fulfillRandomValue(1, 7, uri);
+        vm.stopPrank();
+    }
+
+    function test_fulfillRandomValue_expired() public {
+        vm.startPrank(CONSUMER);
+        vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, 0);
+        vm.stopPrank();
+
+        // Mock expired block hash (return 0)
+        vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockHash(uint256)"), abi.encode(bytes32(0)));
+
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf1, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+
+        vm.prank(CONSUMER);
+        (uint256 retId,, bytes32 retBlockHash, bool expired) = vrf.fulfillRandomValue(1, 7, uri);
+
+        assertEq(retId, 0);
+        assertEq(retBlockHash, bytes32(0));
+        assertTrue(expired);
+    }
+
+    function test_fulfillRandomValue_secondLeaf() public {
+        vm.startPrank(CONSUMER);
+        // Reserve 2 IDs, use the second one (index 1 in epoch)
+        vrf.reserveRequestId(); // id=0
+        uint256 requestId = vrf.reserveRequestId(); // id=1
+        vrf.bindRequest(1, 8, requestId);
+
+        // Proof for leaf1 (index=1): [leaf0, node23]
+        bytes memory rawBytes = abi.encodePacked(RV1, leaf0, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+
+        (uint256 retId, bytes32 retRv,, bool expired) = vrf.fulfillRandomValue(1, 8, uri);
+        vm.stopPrank();
+
+        assertEq(retId, 1);
+        assertEq(retRv, RV1);
+        assertFalse(expired);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       REQUEST EXPIRY
+    //////////////////////////////////////////////////////////////*/
+
+    function test_isRequestExpired_notExpired() public {
+        vm.prank(CONSUMER);
+        uint256 id = vrf.reserveRequestId();
+        assertFalse(vrf.isRequestExpired(id));
+    }
+
+    function test_isRequestExpired_expired() public {
+        vm.prank(CONSUMER);
+        uint256 id = vrf.reserveRequestId();
+
+        // Advance block past timeout (100 + 256 + 1 = 357)
+        vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockNumber()"), abi.encode(uint256(400)));
+        assertTrue(vrf.isRequestExpired(id));
+    }
+
+    function test_isRequestExpired_afterFulfillment() public {
+        vm.startPrank(CONSUMER);
+        vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, 0);
+
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf1, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+        vrf.fulfillRandomValue(1, 7, uri);
+        vm.stopPrank();
+
+        // After fulfillment, blockNum is deleted → treated as expired
+        assertTrue(vrf.isRequestExpired(0));
+    }
+
+    function test_getRequestBlock_afterFulfillment() public {
+        vm.startPrank(CONSUMER);
+        vrf.reserveRequestId();
+        vrf.bindRequest(1, 7, 0);
+
+        bytes memory rawBytes = abi.encodePacked(RV0, leaf1, node23);
+        bytes memory uri = _buildDataUri(rawBytes);
+        vrf.fulfillRandomValue(1, 7, uri);
+        vm.stopPrank();
+
+        // Block number deleted after fulfillment (gas refund)
+        assertEq(vrf.getRequestBlock(0), 0);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                  InvalidOutputData error (Fix #4)
+    //////////////////////////////////////////////////////////////*/
+
+    function test_InvalidOutputData_errorExists() public pure {
+        bytes4 selector = NoosphereVRF.InvalidOutputData.selector;
+        assertTrue(selector != bytes4(0));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                            HELPERS
+    //////////////////////////////////////////////////////////////*/
+
+    function _commHash(bytes32 a, bytes32 b) internal pure returns (bytes32) {
+        return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+
+    function _buildDataUri(bytes memory rawBytes) internal pure returns (bytes memory) {
+        string memory inner = _base64Encode(rawBytes);
+        string memory outer = _base64Encode(bytes(inner));
+        return abi.encodePacked("data:;base64,", outer);
+    }
+
+    function _base64Encode(bytes memory data) internal pure returns (string memory) {
+        bytes memory TABLE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        if (data.length == 0) return "";
+
+        uint256 encodedLen = 4 * ((data.length + 2) / 3);
+        bytes memory result = new bytes(encodedLen);
+
+        for (uint256 i = 0; i < data.length; i += 3) {
+            uint256 a = uint8(data[i]);
+            uint256 b = (i + 1 < data.length) ? uint8(data[i + 1]) : 0;
+            uint256 c = (i + 2 < data.length) ? uint8(data[i + 2]) : 0;
+            uint256 triple = (a << 16) | (b << 8) | c;
+
+            uint256 j = (i / 3) * 4;
+            result[j] = TABLE[(triple >> 18) & 0x3F];
+            result[j + 1] = TABLE[(triple >> 12) & 0x3F];
+            result[j + 2] = (i + 1 < data.length) ? TABLE[(triple >> 6) & 0x3F] : bytes1("=");
+            result[j + 3] = (i + 2 < data.length) ? TABLE[triple & 0x3F] : bytes1("=");
+        }
+
+        return string(result);
+    }
+}
+
+/*//////////////////////////////////////////////////////////////
+        NoosphereVRFConsumer TESTS (Fix #2, #5 + basics)
+//////////////////////////////////////////////////////////////*/
+
+contract NoosphereVRFConsumerTest is Test {
+    TestVRFConsumer public consumer;
+    MockRouter public router;
+    NoosphereVRF public vrf;
+
+    address public constant USER1 = address(0x10);
+    address public constant USER2 = address(0x20);
+
+    // Re-declare events for expectEmit
+    event SubscriptionCreated(uint64 indexed subscriptionId, address indexed owner);
+    event SubscriptionCancelled(uint64 indexed subscriptionId, address indexed owner);
+
+    function setUp() public {
+        vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockNumber()"), abi.encode(uint256(100)));
+
+        router = new MockRouter();
+        vrf = new NoosphereVRF(address(this));
+        vrf.registerEpoch(0, bytes32(uint256(0xDEAD)));
+        consumer = new TestVRFConsumer(address(router), address(this), address(vrf));
+        vrf.addConsumer(address(consumer));
+    }
+
+    function _createSub(address user) internal returns (uint64) {
+        vm.prank(user);
+        return consumer.createSubscription("vrng", false, address(0), 0, address(0), address(0), bytes32(0));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    createSubscription basics
+    //////////////////////////////////////////////////////////////*/
+
+    function test_createSubscription_recordsOwner() public {
+        uint64 sub = _createSub(USER1);
+        assertEq(consumer.getSubscriptionOwner(sub), USER1);
+    }
+
+    function test_createSubscription_addsToUserList() public {
+        _createSub(USER1);
+        _createSub(USER1);
+        assertEq(consumer.getUserSubscriptionCount(USER1), 2);
+    }
+
+    function test_createSubscription_emitsEvent() public {
+        vm.prank(USER1);
+        vm.expectEmit(true, true, false, false);
+        emit SubscriptionCreated(1, USER1); // MockRouter returns 1 for first sub
+        consumer.createSubscription("vrng", false, address(0), 0, address(0), address(0), bytes32(0));
+    }
+
+    function test_createSubscription_multipleUsers_isolated() public {
+        _createSub(USER1);
+        _createSub(USER1);
+        _createSub(USER2);
+
+        assertEq(consumer.getUserSubscriptionCount(USER1), 2);
+        assertEq(consumer.getUserSubscriptionCount(USER2), 1);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+              cancelSubscription cleanup (Fix #2)
+    //////////////////////////////////////////////////////////////*/
+
+    function test_cancelSubscription_removesFromArray() public {
+        uint64 sub1 = _createSub(USER1);
+        uint64 sub2 = _createSub(USER1);
+        uint64 sub3 = _createSub(USER1);
+        assertEq(consumer.getUserSubscriptionCount(USER1), 3);
+
+        vm.prank(USER1);
+        consumer.cancelSubscription(sub2);
+
+        assertEq(consumer.getUserSubscriptionCount(USER1), 2);
+
+        uint64[] memory subs = consumer.getUserSubscriptions(USER1, 0, 10);
+        bool foundSub1;
+        bool foundSub3;
+        for (uint256 i = 0; i < subs.length; i++) {
+            assertTrue(subs[i] != sub2, "Cancelled sub should be removed");
+            if (subs[i] == sub1) foundSub1 = true;
+            if (subs[i] == sub3) foundSub3 = true;
+        }
+        assertTrue(foundSub1, "sub1 should remain");
+        assertTrue(foundSub3, "sub3 should remain");
+    }
+
+    function test_cancelSubscription_clearsOwnership() public {
+        uint64 sub1 = _createSub(USER1);
+        assertEq(consumer.getSubscriptionOwner(sub1), USER1);
+
+        vm.prank(USER1);
+        consumer.cancelSubscription(sub1);
+
+        assertEq(consumer.getSubscriptionOwner(sub1), address(0));
+    }
+
+    function test_cancelSubscription_notOwner_reverts() public {
+        uint64 sub1 = _createSub(USER1);
+
+        vm.prank(USER2);
+        vm.expectRevert(NoosphereVRFConsumer.NotSubscriptionOwner.selector);
+        consumer.cancelSubscription(sub1);
+    }
+
+    function test_cancelSubscription_emitsEvent() public {
+        uint64 sub1 = _createSub(USER1);
+
+        vm.prank(USER1);
+        vm.expectEmit(true, true, false, false);
+        emit SubscriptionCancelled(sub1, USER1);
+        consumer.cancelSubscription(sub1);
+    }
+
+    function test_cancelSubscription_doubleCancelReverts() public {
+        uint64 sub1 = _createSub(USER1);
+
+        vm.prank(USER1);
+        consumer.cancelSubscription(sub1);
+
+        vm.prank(USER1);
+        vm.expectRevert(NoosphereVRFConsumer.NotSubscriptionOwner.selector);
+        consumer.cancelSubscription(sub1);
+    }
+
+    function test_cancelSubscription_cancelAll() public {
+        uint64 sub1 = _createSub(USER1);
+        uint64 sub2 = _createSub(USER1);
+        uint64 sub3 = _createSub(USER1);
+
+        vm.startPrank(USER1);
+        consumer.cancelSubscription(sub1);
+        consumer.cancelSubscription(sub2);
+        consumer.cancelSubscription(sub3);
+        vm.stopPrank();
+
+        assertEq(consumer.getUserSubscriptionCount(USER1), 0);
+        assertEq(consumer.getSubscriptionOwner(sub1), address(0));
+        assertEq(consumer.getSubscriptionOwner(sub2), address(0));
+        assertEq(consumer.getSubscriptionOwner(sub3), address(0));
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                       Pagination (Fix #5)
+    //////////////////////////////////////////////////////////////*/
+
+    function test_pagination_basicPages() public {
+        for (uint256 i = 0; i < 5; i++) {
+            _createSub(USER1);
+        }
+
+        uint64[] memory page1 = consumer.getUserSubscriptions(USER1, 0, 2);
+        assertEq(page1.length, 2);
+
+        uint64[] memory page2 = consumer.getUserSubscriptions(USER1, 2, 2);
+        assertEq(page2.length, 2);
+
+        uint64[] memory page3 = consumer.getUserSubscriptions(USER1, 4, 2);
+        assertEq(page3.length, 1);
+    }
+
+    function test_pagination_offsetBeyondLength() public {
+        _createSub(USER1);
+        uint64[] memory result = consumer.getUserSubscriptions(USER1, 100, 10);
+        assertEq(result.length, 0);
+    }
+
+    function test_pagination_zeroLimit() public {
+        _createSub(USER1);
+        uint64[] memory result = consumer.getUserSubscriptions(USER1, 0, 0);
+        assertEq(result.length, 0);
+    }
+
+    function test_pagination_fullArray() public {
+        uint64 sub1 = _createSub(USER1);
+        uint64 sub2 = _createSub(USER1);
+        uint64 sub3 = _createSub(USER1);
+
+        uint64[] memory all = consumer.getUserSubscriptions(USER1, 0, 100);
+        assertEq(all.length, 3);
+        assertEq(all[0], sub1);
+        assertEq(all[1], sub2);
+        assertEq(all[2], sub3);
+    }
+
+    function test_pagination_noSubscriptions() public view {
+        uint64[] memory result = consumer.getUserSubscriptions(USER1, 0, 10);
+        assertEq(result.length, 0);
+    }
+
+    function test_pagination_correctValues() public {
+        uint64 sub1 = _createSub(USER1);
+        uint64 sub2 = _createSub(USER1);
+        uint64 sub3 = _createSub(USER1);
+        uint64 sub4 = _createSub(USER1);
+
+        uint64[] memory mid = consumer.getUserSubscriptions(USER1, 1, 2);
+        assertEq(mid.length, 2);
+        assertEq(mid[0], sub2);
+        assertEq(mid[1], sub3);
+
+        uint64[] memory last = consumer.getUserSubscriptions(USER1, 3, 10);
+        assertEq(last.length, 1);
+        assertEq(last[0], sub4);
+
+        // Suppress unused variable warnings
+        assertGt(sub1, 0);
+    }
+
+    function test_getUserSubscriptionCount() public {
+        assertEq(consumer.getUserSubscriptionCount(USER1), 0);
+
+        _createSub(USER1);
+        assertEq(consumer.getUserSubscriptionCount(USER1), 1);
+
+        _createSub(USER1);
+        assertEq(consumer.getUserSubscriptionCount(USER1), 2);
+
+        _createSub(USER2);
+        assertEq(consumer.getUserSubscriptionCount(USER2), 1);
+        assertEq(consumer.getUserSubscriptionCount(USER1), 2);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        VIEW FUNCTIONS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_getRouterAddress() public view {
+        assertEq(consumer.getRouterAddress(), address(router));
+    }
+
+    function test_typeAndVersion() public view {
+        assertEq(consumer.typeAndVersion(), "TestVRFConsumer_v1.0.0");
+    }
+}

--- a/test/NoosphereVRF.t.sol
+++ b/test/NoosphereVRF.t.sol
@@ -16,17 +16,10 @@ import {PayloadData} from "../src/v1_0_0/types/PayloadData.sol";
 contract MockRouter {
     uint64 private _nextSubId = 1;
 
-    function createComputeSubscription(
-        string memory,
-        uint32,
-        uint32,
-        bool,
-        address,
-        uint256,
-        address,
-        address,
-        bytes32
-    ) external returns (uint64) {
+    function createComputeSubscription(string memory, uint32, uint32, bool, address, uint256, address, address, bytes32)
+        external
+        returns (uint64)
+    {
         return _nextSubId++;
     }
 
@@ -71,11 +64,7 @@ contract NoosphereVRFCoreTest is Test {
     function setUp() public {
         // Mock ArbSys predeploy at 0x64
         vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockNumber()"), abi.encode(uint256(100)));
-        vm.mockCall(
-            address(0x64),
-            abi.encodeWithSignature("arbBlockHash(uint256)"),
-            abi.encode(keccak256("block100"))
-        );
+        vm.mockCall(address(0x64), abi.encodeWithSignature("arbBlockHash(uint256)"), abi.encode(keccak256("block100")));
 
         vrf = new NoosphereVRF(OWNER);
 


### PR DESCRIPTION
Add VRF module (src/v1_0_0/vrf/) providing epoch-based Merkle tree random values shared across all consumer dApps on a chain.

- INoosphereVRF.sol: Public interface
- NoosphereVRF.sol: Singleton with epoch management, Merkle proof verification, global request ID counter, and replay prevention
- NoosphereVRFConsumer.sol: Abstract for dApps to inherit, integrates with Noosphere compute pipeline and exposes virtual hooks