### PR TITLE
feat: Add mainnet deployment script and orchestrator

### DIFF
--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -1,0 +1,29 @@
+# ─── Network ───
+CHAIN_ID=190415
+RPC_URL=https://mainnet.hpp.io
+
+# ─── Deployer EOA (deployment only — discard key after deployment) ───
+PRIVATE_KEY=
+
+# ─── Safe Multisig Addresses (governance) ───
+# Protocol Owner — Router + Coordinator ownership transfer target
+PRODUCTION_OWNER_ADDR=
+# Verifier Owner — ImmediateFinalizeVerifier ownership transfer target
+IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR=
+# VRF Owner — NoosphereVRF owner
+VRF_OWNER=
+
+# ─── Noosphere Wallet ───
+# Fee Recipient — address for WalletFactory.createWallet()
+INITIAL_FEE_RECIPIENT_ADDR=
+
+# ─── Ops EOA (funding only, optional CLI backup) ───
+OPS_PRIVATE_KEY=
+FUND_PROTOCOL_SAFE=0.3
+FUND_VERIFIER_SAFE=0.1
+FUND_VRF_SAFE=0.5
+
+# ─── Post-deployment verification ───
+ROUTER_ADDR=
+COORDINATOR_ADDR=
+VRF_ADDR=

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ endif
 # -----------------------------------------------------------------------------
 # PHONY targets (force these to run even if a file with the same name exists)
 # -----------------------------------------------------------------------------
-.PHONY: all install clean build test format docs snapshot diff deploy deploy-anvil deploy-hpp-sepolia deploy-vrf deploy-vrf-hpp-sepolia register-epoch
+.PHONY: all install clean build test format docs snapshot diff deploy deploy-anvil deploy-hpp-sepolia deploy-hpp-mainnet deploy-mainnet-test-sepolia deploy-mainnet-full deploy-vrf deploy-vrf-hpp-sepolia deploy-vrf-hpp-mainnet register-epoch register-epoch-mainnet verify-contracts verify-deployment fund-accounts
 
 # -----------------------------------------------------------------------------
 # Default target: run dependency install -> clean -> format -> build -> test
@@ -125,6 +125,156 @@ deploy-hpp-sepolia:
 		--sig "run(address,address)" $(PRODUCTION_OWNER_ADDR) $(INITIAL_FEE_RECIPIENT_ADDR)
 
 # -----------------------------------------------------------------------------
+# Test DeployMainnet.sol on HPP Sepolia (pre-mainnet dry run)
+# - Uses DeployMainnet.sol script with Sepolia explorer for verification
+# - All owner roles should be set to a single test address in .env
+# - Requires: RPC_URL, PRIVATE_KEY, PRODUCTION_OWNER_ADDR, CHAIN_ID,
+#             INITIAL_FEE_RECIPIENT_ADDR, IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR
+# -----------------------------------------------------------------------------
+deploy-mainnet-test-sepolia:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ] || [ -z "$(PRODUCTION_OWNER_ADDR)" ] \
+		|| [ -z "$(CHAIN_ID)" ] || [ -z "$(INITIAL_FEE_RECIPIENT_ADDR)" ] \
+		|| [ -z "$(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)" ]; then \
+		echo "ERROR: RPC_URL, PRIVATE_KEY, PRODUCTION_OWNER_ADDR, CHAIN_ID, INITIAL_FEE_RECIPIENT_ADDR, and IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR are required."; \
+		exit 1; \
+	fi
+	@echo "=> Testing DeployMainnet.sol on HPP Sepolia..."
+	@echo "  Chain ID:              $(CHAIN_ID)"
+	@echo "  Deployer:              (address derived from PRIVATE_KEY)"
+	@echo "  Protocol Safe:         $(PRODUCTION_OWNER_ADDR)"
+	@echo "  Verifier Safe:         $(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)"
+	@echo "  Initial Fee Recipient: $(INITIAL_FEE_RECIPIENT_ADDR)"
+	@echo "  Explorer:              https://sepolia-explorer.hpp.io/api"
+	@forge script scripts/DeployMainnet.sol:DeployMainnet \
+		--skip-simulation \
+		--gas-estimate-multiplier 130 \
+		--optimize \
+		--optimizer-runs 1000000 \
+		--extra-output-files abi \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY) \
+		--broadcast \
+		--verify \
+		--verifier blockscout \
+		--verifier-url https://sepolia-explorer.hpp.io/api/ \
+		--sig "run(address,address)" $(PRODUCTION_OWNER_ADDR) $(INITIAL_FEE_RECIPIENT_ADDR)
+
+# =============================================================================
+# MAINNET DEPLOYMENT ORCHESTRATOR
+# =============================================================================
+# Full mainnet deployment flow with confirmation prompts between steps.
+#
+# Prerequisites:
+#   1. .env loaded with mainnet config (see .env.mainnet.example)
+#   2. Safe multisigs created (Protocol, Verifier, VRF)
+#   3. Deployer EOA funded with ~0.2 ETH for gas
+#
+# Flow:
+#   Step 1: Pre-flight checks (build + test)
+#   Step 2: Core contract deployment (Router, Coordinator, Verifier, etc.)
+#   Step 3: VRF deployment
+#   Step 4: Source code verification on explorer
+#   Step 5: Post-deployment state verification
+#
+# After completion:
+#   - Fund Safe wallets via Ops dashboard
+#   - Protocol Safe: call Router.acceptOwnership() + Coordinator.acceptOwnership()
+#   - VRF Safe: call NoosphereVRF.registerEpoch()
+# =============================================================================
+deploy-mainnet-full:
+	@echo ""
+	@echo "╔══════════════════════════════════════════════════╗"
+	@echo "║        HPP Mainnet Deployment Orchestrator       ║"
+	@echo "╚══════════════════════════════════════════════════╝"
+	@echo ""
+	@echo "  Chain ID:              $(CHAIN_ID)"
+	@echo "  RPC:                   $(RPC_URL)"
+	@echo "  Protocol Safe:         $(PRODUCTION_OWNER_ADDR)"
+	@echo "  Verifier Safe:         $(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)"
+	@echo "  VRF Owner:             $(VRF_OWNER)"
+	@echo "  Fee Recipient:         $(INITIAL_FEE_RECIPIENT_ADDR)"
+	@echo ""
+	@echo "─── Step 1/5: Pre-flight checks ───"
+	@read -p "Run build + tests? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
+	@$(MAKE) build
+	@$(MAKE) test
+	@echo ""
+	@echo "✓ Step 1 complete: build + tests passed"
+	@echo ""
+	@echo "─── Step 2/5: Core contract deployment ───"
+	@echo "  This will deploy Router, Coordinator, WalletFactory, Verifier, Reader"
+	@echo "  and transfer ownership to Safe addresses."
+	@read -p "Deploy core contracts to mainnet? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
+	@$(MAKE) deploy-hpp-mainnet
+	@echo ""
+	@echo "✓ Step 2 complete: core contracts deployed"
+	@echo "  Save the contract addresses from the output above."
+	@echo ""
+	@echo "─── Step 3/5: VRF deployment ───"
+	@read -p "Deploy NoosphereVRF to mainnet? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
+	@$(MAKE) deploy-vrf-hpp-mainnet
+	@echo ""
+	@echo "✓ Step 3 complete: VRF deployed"
+	@echo ""
+	@echo "─── Step 4/5: Source code verification ───"
+	@echo "  Wait ~30s for explorer to index contracts before verifying."
+	@read -p "Verify contract source code on explorer? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
+	@$(MAKE) verify-contracts
+	@echo ""
+	@echo "✓ Step 4 complete: source code verified"
+	@echo ""
+	@echo "─── Step 5/5: Post-deployment state verification ───"
+	@echo "  Set ROUTER_ADDR, COORDINATOR_ADDR, VRF_ADDR in .env first."
+	@read -p "Run state verification? [y/N] " confirm && [ "$$confirm" = "y" ] || exit 1
+	@$(MAKE) verify-deployment
+	@echo ""
+	@echo "╔══════════════════════════════════════════════════╗"
+	@echo "║              Deployment Complete                 ║"
+	@echo "╠══════════════════════════════════════════════════╣"
+	@echo "║  Next steps:                                     ║"
+	@echo "║  1. Fund Safe wallets via Ops dashboard          ║"
+	@echo "║  2. Protocol Safe: acceptOwnership() on Router   ║"
+	@echo "║  3. Protocol Safe: acceptOwnership() on Coord.   ║"
+	@echo "║  4. VRF Safe: registerEpoch(0, merkleRoot)       ║"
+	@echo "╚══════════════════════════════════════════════════╝"
+
+# -----------------------------------------------------------------------------
+# Deploy to HPP Mainnet with contract verification
+# - Deployer acts as temporary Owner (no PRODUCTION_OWNER_PRIVATE_KEY needed)
+# - Phase 1: contract deployment, Phase 2: configuration, Phase 3: ownership transfer
+# - Requires: RPC_URL, PRIVATE_KEY, PRODUCTION_OWNER_ADDR, CHAIN_ID,
+#             INITIAL_FEE_RECIPIENT_ADDR, IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR
+# -----------------------------------------------------------------------------
+deploy-hpp-mainnet:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ] || [ -z "$(PRODUCTION_OWNER_ADDR)" ] \
+		|| [ -z "$(CHAIN_ID)" ] || [ -z "$(INITIAL_FEE_RECIPIENT_ADDR)" ] \
+		|| [ -z "$(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)" ]; then \
+		echo "ERROR: RPC_URL, PRIVATE_KEY, PRODUCTION_OWNER_ADDR, CHAIN_ID, INITIAL_FEE_RECIPIENT_ADDR, and IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR are required."; \
+		exit 1; \
+	fi
+	@echo "=> Running deployment to HPP Mainnet with verification..."
+	@echo "  Chain ID:              $(CHAIN_ID)"
+	@echo "  Deployer:              (address derived from PRIVATE_KEY)"
+	@echo "  Protocol Safe:         $(PRODUCTION_OWNER_ADDR)"
+	@echo "  Verifier Safe:         $(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)"
+	@echo "  Initial Fee Recipient: $(INITIAL_FEE_RECIPIENT_ADDR)"
+	@echo "  Explorer:              https://explorer.hpp.io/api"
+	@forge script scripts/DeployMainnet.sol:DeployMainnet \
+		--skip-simulation \
+		--gas-estimate-multiplier 130 \
+		--optimize \
+		--optimizer-runs 1000000 \
+		--extra-output-files abi \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY) \
+		--broadcast \
+		--sig "run(address,address)" $(PRODUCTION_OWNER_ADDR) $(INITIAL_FEE_RECIPIENT_ADDR)
+	@echo ""
+	@echo "NOTE: Run 'make verify-contracts' after explorer indexes the contracts."
+
+# -----------------------------------------------------------------------------
 # Deploy NoosphereVRF singleton
 # - Requires: RPC_URL, PRIVATE_KEY
 # - Optional: VRF_OWNER (defaults to deployer address)
@@ -181,6 +331,148 @@ register-epoch:
 		--rpc-url $(RPC_URL) \
 		--chain-id $(CHAIN_ID) \
 		--private-key $(PRIVATE_KEY)
+
+# -----------------------------------------------------------------------------
+# Deploy NoosphereVRF to HPP Mainnet with verification
+# - Requires: RPC_URL, PRIVATE_KEY, CHAIN_ID
+# - Optional: VRF_OWNER (defaults to deployer address)
+# -----------------------------------------------------------------------------
+deploy-vrf-hpp-mainnet:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ]; then \
+		echo "ERROR: RPC_URL and PRIVATE_KEY environment variables are required."; \
+		exit 1; \
+	fi
+	@echo "=> Deploying NoosphereVRF to HPP Mainnet..."
+	@forge script scripts/DeployVRF.sol:DeployVRF \
+		--broadcast \
+		--skip-simulation \
+		--gas-estimate-multiplier 130 \
+		--optimize \
+		--optimizer-runs 1000000 \
+		--extra-output-files abi \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY)
+	@echo ""
+	@echo "NOTE: Run 'make verify-contracts' after explorer indexes the contract."
+
+# -----------------------------------------------------------------------------
+# Register epoch on NoosphereVRF (HPP Mainnet)
+# - Requires: RPC_URL, PRIVATE_KEY, VRF_ADDRESS, EPOCH, MERKLE_ROOT
+# -----------------------------------------------------------------------------
+register-epoch-mainnet:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(PRIVATE_KEY)" ] || [ -z "$(VRF_ADDRESS)" ] \
+		|| [ -z "$(EPOCH)" ] || [ -z "$(MERKLE_ROOT)" ]; then \
+		echo "ERROR: RPC_URL, PRIVATE_KEY, VRF_ADDRESS, EPOCH, MERKLE_ROOT are required."; \
+		exit 1; \
+	fi
+	@echo "=> Registering epoch $(EPOCH) on NoosphereVRF $(VRF_ADDRESS)..."
+	@NOOSPHERE_VRF_ADDRESS=$(VRF_ADDRESS) forge script scripts/RegisterEpoch.sol:RegisterEpoch \
+		--broadcast \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY)
+
+# -----------------------------------------------------------------------------
+# Verify contract source code on Blockscout explorer
+# - Re-reads broadcast artifacts and submits verification for all contracts
+# - Run after deploy-hpp-mainnet / deploy-vrf-hpp-mainnet (wait ~30s for indexing)
+# - Requires: RPC_URL, CHAIN_ID, EXPLORER_API_URL
+# - EXPLORER_API_URL defaults to mainnet; override for testnet
+# -----------------------------------------------------------------------------
+EXPLORER_API_URL ?= https://explorer.hpp.io/api/
+
+verify-contracts:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(CHAIN_ID)" ] || [ -z "$(PRIVATE_KEY)" ]; then \
+		echo "ERROR: RPC_URL, CHAIN_ID, and PRIVATE_KEY are required."; \
+		exit 1; \
+	fi
+	@echo "=> Verifying contract source code on $(EXPLORER_API_URL)..."
+	@echo ""
+	@echo "--- Core contracts (DeployMainnet.sol) ---"
+	@forge script scripts/DeployMainnet.sol:DeployMainnet \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY) \
+		--optimize --optimizer-runs 1000000 \
+		--verify \
+		--verifier blockscout \
+		--verifier-url $(EXPLORER_API_URL) \
+		--resume \
+		--sig "run(address,address)" $(PRODUCTION_OWNER_ADDR) $(INITIAL_FEE_RECIPIENT_ADDR) || true
+	@echo ""
+	@echo "--- VRF contract (DeployVRF.sol) ---"
+	@forge script scripts/DeployVRF.sol:DeployVRF \
+		--rpc-url $(RPC_URL) \
+		--chain-id $(CHAIN_ID) \
+		--private-key $(PRIVATE_KEY) \
+		--optimize --optimizer-runs 1000000 \
+		--verify \
+		--verifier blockscout \
+		--verifier-url $(EXPLORER_API_URL) \
+		--resume || true
+	@echo ""
+	@echo "=> Source verification complete."
+
+# -----------------------------------------------------------------------------
+# Verify deployment — post-deployment state checks via cast call
+# - Requires: RPC_URL, ROUTER_ADDR, COORDINATOR_ADDR
+# - Optional: VRF_ADDR, PRODUCTION_OWNER_ADDR
+# -----------------------------------------------------------------------------
+verify-deployment:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(ROUTER_ADDR)" ] || [ -z "$(COORDINATOR_ADDR)" ]; then \
+		echo "ERROR: RPC_URL, ROUTER_ADDR, and COORDINATOR_ADDR are required."; \
+		exit 1; \
+	fi
+	@echo "=> Verifying on-chain state..."
+	@echo ""
+	@echo "--- Ownership ---"
+	@echo -n "  Router owner:        "; cast call $(ROUTER_ADDR) "client()(address)" --rpc-url $(RPC_URL)
+	@echo -n "  Coordinator owner:   "; cast call $(COORDINATOR_ADDR) "client()(address)" --rpc-url $(RPC_URL)
+	@if [ -n "$(VRF_ADDR)" ]; then \
+		echo -n "  VRF owner:           "; cast call $(VRF_ADDR) "owner()(address)" --rpc-url $(RPC_URL); \
+	fi
+	@echo ""
+	@echo "--- Configuration ---"
+	@echo -n "  WalletFactory:       "; cast call $(ROUTER_ADDR) "getWalletFactory()(address)" --rpc-url $(RPC_URL)
+	@echo -n "  Router paused:       "; cast call $(ROUTER_ADDR) "paused()(bool)" --rpc-url $(RPC_URL)
+	@echo -n "  Coordinator init:    "; cast call $(COORDINATOR_ADDR) "getProtocolFee()(uint96)" --rpc-url $(RPC_URL) 2>/dev/null && echo "" || echo "  (check manually)"
+	@if [ -n "$(VRF_ADDR)" ]; then \
+		echo -n "  VRF EPOCH_SIZE:      "; cast call $(VRF_ADDR) "EPOCH_SIZE()(uint256)" --rpc-url $(RPC_URL); \
+	fi
+	@echo ""
+	@if [ -n "$(PRODUCTION_OWNER_ADDR)" ]; then \
+		echo "--- Expected owner: $(PRODUCTION_OWNER_ADDR) ---"; \
+	fi
+	@echo "=> State verification complete."
+
+# -----------------------------------------------------------------------------
+# Fund accounts — optional CLI backup for Safe funding (Ops EOA only)
+# - Requires: RPC_URL, OPS_PRIVATE_KEY
+# - Amounts from FUND_* environment variables
+# -----------------------------------------------------------------------------
+fund-accounts:
+	@if [ -z "$(RPC_URL)" ] || [ -z "$(OPS_PRIVATE_KEY)" ]; then \
+		echo "ERROR: RPC_URL and OPS_PRIVATE_KEY are required."; \
+		exit 1; \
+	fi
+	@echo "=> Funding accounts (Source: Ops EOA)..."
+	@if [ -n "$(FUND_PROTOCOL_SAFE)" ] && [ -n "$(PRODUCTION_OWNER_ADDR)" ]; then \
+		echo "  Funding Protocol Safe ($(PRODUCTION_OWNER_ADDR)) with $(FUND_PROTOCOL_SAFE) ETH"; \
+		cast send $(PRODUCTION_OWNER_ADDR) --value $(FUND_PROTOCOL_SAFE)ether \
+			--rpc-url $(RPC_URL) --private-key $(OPS_PRIVATE_KEY); \
+	fi
+	@if [ -n "$(FUND_VERIFIER_SAFE)" ] && [ -n "$(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)" ]; then \
+		echo "  Funding Verifier Safe ($(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR)) with $(FUND_VERIFIER_SAFE) ETH"; \
+		cast send $(IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR) --value $(FUND_VERIFIER_SAFE)ether \
+			--rpc-url $(RPC_URL) --private-key $(OPS_PRIVATE_KEY); \
+	fi
+	@if [ -n "$(FUND_VRF_SAFE)" ] && [ -n "$(VRF_OWNER)" ]; then \
+		echo "  Funding VRF Safe ($(VRF_OWNER)) with $(FUND_VRF_SAFE) ETH"; \
+		cast send $(VRF_OWNER) --value $(FUND_VRF_SAFE)ether \
+			--rpc-url $(RPC_URL) --private-key $(OPS_PRIVATE_KEY); \
+	fi
+	@echo "=> Funding complete."
 
 # -----------------------------------------------------------------------------
 # Save gas snapshot (using forge snapshot)

--- a/scripts/DeployMainnet.sol
+++ b/scripts/DeployMainnet.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BSD-3-Clause-Clear
+pragma solidity 0.8.24;
+
+import {Script} from "forge-std/Script.sol";
+import {console} from "forge-std/console.sol";
+import {BillingConfig} from "../src/v1_0_0/types/BillingConfig.sol";
+import {DelegateeCoordinator} from "../src/v1_0_0/DelegateeCoordinator.sol";
+import {ImmediateFinalizeVerifier} from "../src/v1_0_0/verifier/ImmediateFinalizeVerifier.sol";
+import {Router} from "../src/v1_0_0/Router.sol";
+import {SubscriptionBatchReader} from "../src/v1_0_0/utility/SubscriptionBatchReader.sol";
+import {WalletFactory} from "../src/v1_0_0/wallet/WalletFactory.sol";
+
+/// @title DeployMainnet
+/// @notice Deploys noosphere protocol to mainnet. The Deployer acts as temporary Owner,
+///         performing contract deployment (Phase 1), configuration (Phase 2), and ownership
+///         transfer to Safe multisigs (Phase 3) in a single script execution.
+///
+/// Required environment variables:
+///   PRIVATE_KEY                              – Deployer private key (temporary owner)
+///   IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR   – Verifier Safe address
+///
+/// Usage:
+///   forge script scripts/DeployMainnet.sol:DeployMainnet \
+///     --broadcast --rpc-url $RPC_URL \
+///     --sig "run(address,address)" <PROTOCOL_SAFE> <FEE_RECIPIENT>
+contract DeployMainnet is Script {
+    function run(address _protocolSafe, address _initialFeeRecipient) public {
+        address deployer = msg.sender;
+        address verifierSafe = vm.envAddress("IMMEDIATE_FINALIZE_VERIFIER_OWNER_ADDR");
+
+        require(_protocolSafe != address(0), "DeployMainnet: Protocol Safe address cannot be zero");
+        require(_initialFeeRecipient != address(0), "DeployMainnet: Fee recipient address cannot be zero");
+        require(verifierSafe != address(0), "DeployMainnet: Verifier Safe address cannot be zero");
+        require(_protocolSafe != deployer, "DeployMainnet: Protocol Safe must differ from deployer");
+
+        console.log("=== DeployMainnet: environment ===");
+        console.log("Deployer:          ", deployer);
+        console.log("Chain ID:          ", block.chainid);
+        console.log("Protocol Safe:     ", _protocolSafe);
+        console.log("Verifier Safe:     ", verifierSafe);
+        console.log("Fee Recipient:     ", _initialFeeRecipient);
+        console.log("==================================");
+
+        vm.startBroadcast();
+
+        // ─── Phase 1: Contract deployment (Deployer = temporary Owner) ───
+
+        Router router = new Router(deployer);
+        DelegateeCoordinator coordinator = new DelegateeCoordinator(address(router), deployer);
+        SubscriptionBatchReader reader = new SubscriptionBatchReader(address(router), address(coordinator));
+        WalletFactory walletFactory = new WalletFactory(address(router));
+        ImmediateFinalizeVerifier verifier = new ImmediateFinalizeVerifier(address(coordinator), deployer);
+
+        // ─── Phase 2: Configuration (Deployer as temporary Owner) ───
+
+        router.setWalletFactory(address(walletFactory));
+
+        address protocolWallet = walletFactory.createWallet(_initialFeeRecipient);
+
+        coordinator.initialize(
+            BillingConfig({
+                verificationTimeout: 1 weeks,
+                protocolFeeRecipient: protocolWallet,
+                protocolFee: 100, // 1%
+                tickNodeFee: 0,
+                tickNodeFeeToken: address(0)
+            })
+        );
+
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = "Coordinator_v1.0.0";
+        address[] memory addrs = new address[](1);
+        addrs[0] = address(coordinator);
+
+        router.proposeContractsUpdate(ids, addrs);
+        router.updateContracts();
+
+        verifier.setTokenSupported(address(0), true);
+        coordinator.setSubscriptionBatchReader(address(reader));
+
+        // ─── Phase 3: Ownership transfer (Deployer → Safe) ───
+
+        // Router & Coordinator: ConfirmedOwner (2-step transfer)
+        // Safe must call acceptOwnership() after this script completes
+        router.transferOwnership(_protocolSafe);
+        coordinator.transferOwnership(_protocolSafe);
+
+        // Verifier: OZ Ownable (1-step transfer, immediate)
+        verifier.transferOwnership(verifierSafe);
+
+        vm.stopBroadcast();
+
+        // ─── Summary ───
+
+        console.log("=== DeployMainnet: summary ===");
+        console.log("Router:              ", address(router));
+        console.log("Coordinator:         ", address(coordinator));
+        console.log("Reader:              ", address(reader));
+        console.log("WalletFactory:       ", address(walletFactory));
+        console.log("Verifier:            ", address(verifier));
+        console.log("Protocol Wallet:     ", protocolWallet);
+        console.log("==============================");
+        console.log("");
+        console.log("NEXT STEPS:");
+        console.log("  1. Fund Protocol Safe with gas via Ops dashboard");
+        console.log("  2. Protocol Safe: call Router.acceptOwnership()");
+        console.log("  3. Protocol Safe: call Coordinator.acceptOwnership()");
+        console.log("  4. Deploy VRF: make deploy-vrf-hpp-mainnet");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `DeployMainnet.sol`: single-script deployment where Deployer acts as temporary Owner (deploy → configure → transfer ownership to Safe multisigs)
- Add Makefile targets: `deploy-hpp-mainnet`, `deploy-mainnet-full` (5-step orchestrator), `deploy-mainnet-test-sepolia`, `deploy-vrf-hpp-mainnet`, `verify-contracts`, `verify-deployment`, `fund-accounts`
- Separate broadcast and source verification steps to avoid explorer indexing race condition (`verify-contracts` uses `--resume` on broadcast artifacts)
- Add `.env.mainnet.example` template

## Test plan

- [x] `forge build` passes
- [x] End-to-end deployment tested on HPP Sepolia (chain 181228)
- [x] All 6 contracts deployed and verified on Blockscout explorer
- [x] Ownership transfer verified: Router/Coordinator (2-step `acceptOwnership()`), Verifier (1-step), VRF (constructor)
- [x] `make verify-contracts` and `make verify-deployment` tested against live deployment

Closes #39